### PR TITLE
Enables security hub for all AWS Organization accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Terraform module to setup and manage various components of the AWS Landing Zone.
 
 | Name | Version |
 |------|---------|
+| aws | ~> 3.7.0 |
 | okta | ~> 3.0 |
 
 ## Inputs
@@ -23,6 +24,7 @@ Terraform module to setup and manage various components of the AWS Landing Zone.
 | audit\_account\_id | Account ID of AWS audit account | `string` | n/a | yes |
 | aws\_sso\_acs\_url | AWS SSO ACS URL for the Okta App | `string` | n/a | yes |
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
+| control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
 
 ## Outputs

--- a/audit.tf
+++ b/audit.tf
@@ -1,0 +1,18 @@
+data "aws_organizations_organization" "default" {}
+
+provider "aws" {
+  alias = "audit"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.control_tower_account_ids.audit}:role/AWSControlTowerExecution"
+  }
+}
+
+module "security_hub_audit" {
+  source    = "./modules/security_hub"
+  providers = { aws = aws.audit }
+
+  member_accounts = {
+    for account in data.aws_organizations_organization.default.accounts : account.id => account.email if account.id != var.control_tower_account_ids.audit
+  }
+}

--- a/logging.tf
+++ b/logging.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  alias = "logging"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.control_tower_account_ids.logging}:role/AWSControlTowerExecution"
+  }
+}
+
+module "security_hub_logging" {
+  source    = "./modules/security_hub"
+  providers = { aws = aws.logging }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,3 @@
-provider "aws" {
-  alias = "audit"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${var.audit_account_id}:role/AWSControlTowerExecution"
-  }
-}
-
 module "kms_key" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.5"
   name        = "inception"
@@ -13,7 +5,6 @@ module "kms_key" {
   tags        = var.tags
 }
 
-module "security_hub" {
-  source    = "./modules/security_hub"
-  providers = { aws = aws.audit }
+module "security_hub_master" {
+  source = "./modules/security_hub"
 }

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -37,6 +37,11 @@ resource "aws_iam_account_alias" "alias" {
   account_alias = local.prefixed_name
 }
 
+module "security_hub" {
+  source    = "../security_hub"
+  providers = { aws = aws.managed_by_inception }
+}
+
 module "workspace" {
   source                 = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.2.2"
   providers              = { aws = aws.managed_by_inception }

--- a/modules/security_hub/README.md
+++ b/modules/security_hub/README.md
@@ -19,6 +19,7 @@ Terraform module to setup and manage AWS Security Hub.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| member\_accounts | A map of accounts that should be added as SecurityHub Member Accounts (format: account\_id = email) | `map` | `{}` | no |
 | product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list` | `[]` | no |
 | region | The name of the AWS region where SecurityHub will be enabled | `string` | `"eu-west-1"` | no |
 

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -6,16 +6,24 @@ locals {
   ]
 }
 
-resource "aws_securityhub_account" "this" {}
+resource "aws_securityhub_account" "default" {}
 
-resource "aws_securityhub_product_subscription" "this" {
-  for_each    = toset(var.product_arns)
-  product_arn = each.value
-  depends_on  = [aws_securityhub_account.this]
+resource "aws_securityhub_member" "default" {
+  for_each   = var.member_accounts
+  account_id = each.key
+  email      = each.value
+  invite     = true
+  depends_on = [aws_securityhub_account.default]
 }
 
-resource "aws_securityhub_standards_subscription" "this" {
+resource "aws_securityhub_product_subscription" "default" {
+  for_each    = toset(var.product_arns)
+  product_arn = each.value
+  depends_on  = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_subscription" "default" {
   for_each      = toset(local.standards_arns)
   standards_arn = each.value
-  depends_on    = [aws_securityhub_account.this]
+  depends_on    = [aws_securityhub_account.default]
 }

--- a/modules/security_hub/variables.tf
+++ b/modules/security_hub/variables.tf
@@ -1,3 +1,9 @@
+variable "member_accounts" {
+  type        = map
+  default     = {}
+  description = "A map of accounts that should be added as SecurityHub Member Accounts (format: account_id = email)"
+}
+
 variable "product_arns" {
   type        = list
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,14 @@ variable "aws_sso_entity_id" {
   description = "AWS SSO Entity ID for the Okta App"
 }
 
+variable "control_tower_account_ids" {
+  type = object({
+    audit   = string
+    logging = string
+  })
+  description = "Control Tower core account IDs"
+}
+
 variable "tags" {
   type        = map
   description = "Map of tags"


### PR DESCRIPTION
This change enables SecurityHub for core accounts (`master`, `audit`, and `logging`) and accounts created using the Account Vending Machine (`avm`) module.

It also sends invites from SecurityHub in the `audit` account to all accounts belonging to the AWS Organization. The invite still has to be accepted manually while the [accept invite Terraform resource](https://github.com/terraform-providers/terraform-provider-aws/pull/10003) is not available.