### PR TITLE
Adds support for AWS Config Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| audit\_account\_id | Account ID of AWS audit account | `string` | n/a | yes |
 | aws\_sso\_acs\_url | AWS SSO ACS URL for the Okta App | `string` | n/a | yes |
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
+| aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # terraform-aws-mcaf-landing-zone
 Terraform module to setup and manage various components of the AWS Landing Zone.
 
+## AWS Config Rules
+
+This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed to the variable `aws_config_rules` like in the example below:
+
+```hcl
+aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
+```
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,21 @@
+locals {
+  aws_config_rules = concat(
+    var.aws_config_rules,
+    [
+      "CLOUD_TRAIL_ENABLED",
+      "ENCRYPTED_VOLUMES",
+      "ROOT_ACCOUNT_MFA_ENABLED",
+      "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+    ]
+  )
+}
+
+resource "aws_config_organization_managed_rule" "default" {
+  for_each        = toset(local.aws_config_rules)
+  name            = each.value
+  rule_identifier = each.value
+}
+
 module "kms_key" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.5"
   name        = "inception"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
-variable "audit_account_id" {
-  type        = string
-  description = "Account ID of AWS audit account"
+variable "aws_config_rules" {
+  type        = list
+  default     = []
+  description = "List of managed AWS Config Rule identifiers that should be deployed across the organization"
 }
 
 variable "aws_sso_acs_url" {


### PR DESCRIPTION
This change adds support for AWS Config Rules. 

Since we are using AWS Control Tower, Config is already enabled in the accounts. What this change adds is the possibility of passing a list of AWS Config Rules that will be provisioned at the organization level.

A basic set of Config Rules is added by default.