### PR TITLE
Adds support for AWS-Datadog integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,10 @@ aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
 
-In order to enable the integration, you can pass an object to the variable `datadog_integration` containing the following attributes: (Note: `enabled` and `forward_logs` should be set for each core account)
-- `api_key`: Datadog API Key.
-- `enabled`: boolean indicating if the integration should be enabled.
-- `forward_logs`: boolean indicating if logs should be forwarded to Datadog.
-
-Example:
-```hcl
-datadog_integration = {
-  api_key = "abc123"
-  audit = {
-    enabled      = true
-    forward_logs = false
-  }
-  logging = {
-    enabled      = true
-    forward_logs = true
-  }
-  master = {
-    enabled      = true
-    forward_logs = false
-  }
-}
-```
+In order to enable the integration, you can pass an object to the variable `datadog` containing the following attributes:
+- `api_key`: sets the Datadog API key
+- `enable_integration`: set to `true` to configure the [Datadog AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/)
+- `install_log_forwarder`: set to `true` to install the [Datadog Forwarder](https://docs.datadoghq.com/serverless/forwarder/)
 
 In case you don't want to use the integration, you can configure the Datadog provider like in the example below:
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
 
 In order to enable the integration, you can pass an object to the variable `datadog` containing the following attributes:
+
 - `api_key`: sets the Datadog API key
 - `enable_integration`: set to `true` to configure the [Datadog AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/)
 - `install_log_forwarder`: set to `true` to install the [Datadog Forwarder](https://docs.datadoghq.com/serverless/forwarder/)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 | aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog\_api\_key | Datadog API key | `string` | `null` | no |
-| datadog\_install\_log\_forwarder | Set to true to install Datadog AWS Log Forwarder for each of the core accounts | <pre>object({<br>    audit   = bool<br>    logging = bool<br>    master  = bool<br>  })</pre> | <pre>{<br>  "audit": false,<br>  "logging": false,<br>  "master": false<br>}</pre> | no |
-| datadog\_integration | Whether the Datadog integration should be enabled or not | `bool` | `false` | no |
+| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    audit = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    logging = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    master = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>  })</pre> | <pre>{<br>  "audit": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "logging": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "master": {<br>    "enabled": false,<br>    "forward_logs": false<br>  }<br>}</pre> | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | tags | Map of tags | `map` | n/a | yes |
 | aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
-| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    api_key = string<br>    audit = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    logging = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    master = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>  })</pre> | <pre>{<br>  "api_key": null,<br>  "audit": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "logging": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "master": {<br>    "enabled": false,<br>    "forward_logs": false<br>  }<br>}</pre> | no |
+| datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,44 @@ This module provisions by default a set of basic AWS Config Rules. In order to a
 aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 ```
 
+## Datadog Integration
+
+This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
+
+In order to enable the integration, you can pass an object to the variable `datadog_integration` containing the following attributes: (Note: `enabled` and `forward_logs` should be set for each core account)
+- `api_key`: Datadog API Key.
+- `enabled`: boolean indicating if the integration should be enabled.
+- `forward_logs`: boolean indicating if logs should be forwarded to Datadog.
+
+Example:
+```hcl
+datadog_integration = {
+  api_key = "abc123"
+  audit = {
+    enabled      = true
+    forward_logs = false
+  }
+  logging = {
+    enabled      = true
+    forward_logs = true
+  }
+  master = {
+    enabled      = true
+    forward_logs = false
+  }
+}
+```
+
+In case you don't want to use the integration, you can configure the Datadog provider like in the example below:
+
+```hcl
+provider "datadog" {
+  validate = false
+}
+```
+
+This should prevent the provider from asking you for a Datadog API Key and allow the module to be provisioned without the integration resources.
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 | tags | Map of tags | `map` | n/a | yes |
 | aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
+| datadog\_api\_key | Datadog API key | `string` | `null` | no |
+| datadog\_install\_log\_forwarder | Set to true to install Datadog AWS Log Forwarder for each of the core accounts | <pre>object({<br>    audit   = bool<br>    logging = bool<br>    master  = bool<br>  })</pre> | <pre>{<br>  "audit": false,<br>  "logging": false,<br>  "master": false<br>}</pre> | no |
+| datadog\_integration | Whether the Datadog integration should be enabled or not | `bool` | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | tags | Map of tags | `map` | n/a | yes |
 | aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
-| datadog\_api\_key | Datadog API key | `string` | `null` | no |
-| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    audit = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    logging = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    master = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>  })</pre> | <pre>{<br>  "audit": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "logging": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "master": {<br>    "enabled": false,<br>    "forward_logs": false<br>  }<br>}</pre> | no |
+| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    api_key = string<br>    audit = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    logging = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>    master = object({<br>      enabled      = bool<br>      forward_logs = bool<br>    })<br>  })</pre> | <pre>{<br>  "api_key": null,<br>  "audit": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "logging": {<br>    "enabled": false,<br>    "forward_logs": false<br>  },<br>  "master": {<br>    "enabled": false,<br>    "forward_logs": false<br>  }<br>}</pre> | no |
 
 ## Outputs
 

--- a/audit.tf
+++ b/audit.tf
@@ -9,11 +9,11 @@ provider "aws" {
 }
 
 module "datadog_audit" {
-  count                 = var.datadog_integration == true ? 1 : 0
-  providers             = { aws = aws.audit }
+  count                 = var.datadog_integration.audit.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  providers             = { aws = aws.audit }
   api_key               = var.datadog_api_key
-  install_log_forwarder = var.datadog_install_log_forwarder.audit
+  install_log_forwarder = var.datadog_integration.audit.forward_logs
   tags                  = var.tags
 }
 

--- a/audit.tf
+++ b/audit.tf
@@ -9,11 +9,11 @@ provider "aws" {
 }
 
 module "datadog_audit" {
-  count                 = var.datadog_integration.audit.enabled == true ? 1 : 0
+  count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.audit }
-  api_key               = var.datadog_integration.api_key
-  install_log_forwarder = var.datadog_integration.audit.forward_logs
+  api_key               = try(var.datadog.api_key, null)
+  install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
 }
 

--- a/audit.tf
+++ b/audit.tf
@@ -8,6 +8,15 @@ provider "aws" {
   }
 }
 
+module "datadog_audit" {
+  count                 = var.datadog_integration == true ? 1 : 0
+  providers             = { aws = aws.audit }
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  api_key               = var.datadog_api_key
+  install_log_forwarder = var.datadog_install_log_forwarder.audit
+  tags                  = var.tags
+}
+
 module "security_hub_audit" {
   source    = "./modules/security_hub"
   providers = { aws = aws.audit }

--- a/audit.tf
+++ b/audit.tf
@@ -12,7 +12,7 @@ module "datadog_audit" {
   count                 = var.datadog_integration.audit.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.audit }
-  api_key               = var.datadog_api_key
+  api_key               = var.datadog_integration.api_key
   install_log_forwarder = var.datadog_integration.audit.forward_logs
   tags                  = var.tags
 }

--- a/logging.tf
+++ b/logging.tf
@@ -7,11 +7,11 @@ provider "aws" {
 }
 
 module "datadog_logging" {
-  count                 = var.datadog_integration == true ? 1 : 0
-  providers             = { aws = aws.logging }
+  count                 = var.datadog_integration.logging.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  providers             = { aws = aws.logging }
   api_key               = var.datadog_api_key
-  install_log_forwarder = var.datadog_install_log_forwarder.logging
+  install_log_forwarder = var.datadog_integration.logging.forward_logs
   tags                  = var.tags
 }
 

--- a/logging.tf
+++ b/logging.tf
@@ -10,7 +10,7 @@ module "datadog_logging" {
   count                 = var.datadog_integration.logging.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.logging }
-  api_key               = var.datadog_api_key
+  api_key               = var.datadog_integration.api_key
   install_log_forwarder = var.datadog_integration.logging.forward_logs
   tags                  = var.tags
 }

--- a/logging.tf
+++ b/logging.tf
@@ -7,11 +7,11 @@ provider "aws" {
 }
 
 module "datadog_logging" {
-  count                 = var.datadog_integration.logging.enabled == true ? 1 : 0
+  count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.logging }
-  api_key               = var.datadog_integration.api_key
-  install_log_forwarder = var.datadog_integration.logging.forward_logs
+  api_key               = try(var.datadog.api_key, null)
+  install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
 }
 

--- a/logging.tf
+++ b/logging.tf
@@ -6,6 +6,15 @@ provider "aws" {
   }
 }
 
+module "datadog_logging" {
+  count                 = var.datadog_integration == true ? 1 : 0
+  providers             = { aws = aws.logging }
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  api_key               = var.datadog_api_key
+  install_log_forwarder = var.datadog_install_log_forwarder.logging
+  tags                  = var.tags
+}
+
 module "security_hub_logging" {
   source    = "./modules/security_hub"
   providers = { aws = aws.logging }

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "aws_config_organization_managed_rule" "default" {
 }
 
 module "datadog_master" {
-  count                 = var.datadog_integration.master.enabled == true ? 1 : 0
+  count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
-  api_key               = var.datadog_integration.api_key
-  install_log_forwarder = var.datadog_integration.master.forward_logs
+  api_key               = try(var.datadog.api_key, null)
+  install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "aws_config_organization_managed_rule" "default" {
 }
 
 module "datadog_master" {
-  count                 = var.datadog_integration == true ? 1 : 0
+  count                 = var.datadog_integration.master.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   api_key               = var.datadog_api_key
-  install_log_forwarder = var.datadog_install_log_forwarder.master
+  install_log_forwarder = var.datadog_integration.master.forward_logs
   tags                  = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_config_organization_managed_rule" "default" {
 module "datadog_master" {
   count                 = var.datadog_integration.master.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
-  api_key               = var.datadog_api_key
+  api_key               = var.datadog_integration.api_key
   install_log_forwarder = var.datadog_integration.master.forward_logs
   tags                  = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,14 @@ resource "aws_config_organization_managed_rule" "default" {
   rule_identifier = each.value
 }
 
+module "datadog_master" {
+  count                 = var.datadog_integration == true ? 1 : 0
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  api_key               = var.datadog_api_key
+  install_log_forwarder = var.datadog_install_log_forwarder.master
+  tags                  = var.tags
+}
+
 module "kms_key" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.5"
   name        = "inception"

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -55,8 +55,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | defaults | Default options for this module | <pre>object({<br>    account_prefix         = string<br>    github_organization    = string<br>    sso_email              = string<br>    terraform_organization = string<br>    terraform_version      = string<br>  })</pre> | n/a | yes |
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
-| datadog\_api\_key | Datadog API key | `string` | `null` | no |
-| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    enabled      = bool<br>    forward_logs = bool<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "forward_logs": false<br>}</pre> | no |
+| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    api_key      = string<br>    enabled      = bool<br>    forward_logs = bool<br>  })</pre> | <pre>{<br>  "api_key": null,<br>  "enabled": false,<br>  "forward_logs": false<br>}</pre> | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -44,8 +44,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | datadog\_api\_key | Datadog API key | `string` | `null` | no |
-| datadog\_install\_log\_forwarder | Set to true to install Datadog AWS Log Forwarder | `bool` | `false` | no |
-| datadog\_integration | Whether the Datadog integration should be enabled or not | `bool` | `false` | no |
+| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    enabled      = bool<br>    forward_logs = bool<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "forward_logs": false<br>}</pre> | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -2,6 +2,22 @@
 
 Terraform module to provision an AWS account with a TFE workspace backed by a VCS project.
 
+## Datadog Integration
+
+This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
+
+In order to enable the integration, you will need to set the variable `datadog_integration` to `true` and provide a Datadog API Key using the variable `datadog_api_key`. If you would also like to forward logs to Datadog, you can set the variable `datadog_install_log_forwarder` to `true`.
+
+In case you don't want to use the integration, you can configure the Datadog provider like in the example below:
+
+```hcl
+provider "datadog" {
+  validate = false
+}
+```
+
+This should prevent the provider from asking you for a Datadog API Key and allow the module to be provisioned without the integration resources.
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -6,19 +6,10 @@ Terraform module to provision an AWS account with a TFE workspace backed by a VC
 
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
 
-In order to enable the integration, you can pass an object to the variable `datadog_integration` containing the following attributes:
-- `api_key`: Datadog API Key.
-- `enabled`: boolean indicating if the integration should be enabled.
-- `forward_logs`: boolean indicating if logs should be forwarded to Datadog.
-
-Example:
-```hcl
-datadog_integration = {
-  api_key      = "abc123"
-  enabled      = true
-  forward_logs = true
-}
-```
+In order to enable the integration, you can pass an object to the variable `datadog` containing the following attributes:
+- `api_key`: sets the Datadog API key
+- `enable_integration`: set to `true` to configure the [Datadog AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/)
+- `install_log_forwarder`: set to `true` to install the [Datadog Forwarder](https://docs.datadoghq.com/serverless/forwarder/)
 
 In case you don't want to use the integration, you can configure the Datadog provider like in the example below:
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -46,7 +46,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | defaults | Default options for this module | <pre>object({<br>    account_prefix         = string<br>    github_organization    = string<br>    sso_email              = string<br>    terraform_organization = string<br>    terraform_version      = string<br>  })</pre> | n/a | yes |
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
-| datadog\_integration | Configuration for Datadog Integration | <pre>object({<br>    api_key      = string<br>    enabled      = bool<br>    forward_logs = bool<br>  })</pre> | <pre>{<br>  "api_key": null,<br>  "enabled": false,<br>  "forward_logs": false<br>}</pre> | no |
+| datadog | Datadog integration options | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -7,6 +7,7 @@ Terraform module to provision an AWS account with a TFE workspace backed by a VC
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
 
 In order to enable the integration, you can pass an object to the variable `datadog` containing the following attributes:
+
 - `api_key`: sets the Datadog API key
 - `enable_integration`: set to `true` to configure the [Datadog AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/)
 - `install_log_forwarder`: set to `true` to install the [Datadog Forwarder](https://docs.datadoghq.com/serverless/forwarder/)

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -25,6 +25,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 |------|---------|
 | terraform | >= 0.13 |
 | aws | ~> 3.7.0 |
+| datadog | ~> 2.14 |
 | github | ~> 3.1.0 |
 | mcaf | ~> 0.1.0 |
 | tfe | ~> 0.21.0 |
@@ -42,6 +43,9 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | defaults | Default options for this module | <pre>object({<br>    account_prefix         = string<br>    github_organization    = string<br>    sso_email              = string<br>    terraform_organization = string<br>    terraform_version      = string<br>  })</pre> | n/a | yes |
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
+| datadog\_api\_key | Datadog API key | `string` | `null` | no |
+| datadog\_install\_log\_forwarder | Set to true to install Datadog AWS Log Forwarder | `bool` | `false` | no |
+| datadog\_integration | Whether the Datadog integration should be enabled or not | `bool` | `false` | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -6,7 +6,19 @@ Terraform module to provision an AWS account with a TFE workspace backed by a VC
 
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.
 
-In order to enable the integration, you will need to set the variable `datadog_integration` to `true` and provide a Datadog API Key using the variable `datadog_api_key`. If you would also like to forward logs to Datadog, you can set the variable `datadog_install_log_forwarder` to `true`.
+In order to enable the integration, you can pass an object to the variable `datadog_integration` containing the following attributes:
+- `api_key`: Datadog API Key.
+- `enabled`: boolean indicating if the integration should be enabled.
+- `forward_logs`: boolean indicating if logs should be forwarded to Datadog.
+
+Example:
+```hcl
+datadog_integration = {
+  api_key      = "abc123"
+  enabled      = true
+  forward_logs = true
+}
+```
 
 In case you don't want to use the integration, you can configure the Datadog provider like in the example below:
 

--- a/modules/avm/datadog.tf
+++ b/modules/avm/datadog.tf
@@ -1,8 +1,8 @@
 module "datadog" {
-  count                 = var.datadog_integration.enabled == true ? 1 : 0
+  count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.managed_by_inception }
-  api_key               = var.datadog_integration.api_key
-  install_log_forwarder = var.datadog_integration.forward_logs
+  api_key               = try(var.datadog.api_key, null)
+  install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = local.tags
 }

--- a/modules/avm/datadog.tf
+++ b/modules/avm/datadog.tf
@@ -1,7 +1,7 @@
 module "datadog" {
   count                 = var.datadog_integration == true ? 1 : 0
-  providers             = { aws = aws.managed_by_inception }
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  providers             = { aws = aws.managed_by_inception }
   api_key               = var.datadog_api_key
   install_log_forwarder = var.datadog_install_log_forwarder
   tags                  = local.tags

--- a/modules/avm/datadog.tf
+++ b/modules/avm/datadog.tf
@@ -1,8 +1,8 @@
 module "datadog" {
-  count                 = var.datadog_integration == true ? 1 : 0
+  count                 = var.datadog_integration.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.managed_by_inception }
   api_key               = var.datadog_api_key
-  install_log_forwarder = var.datadog_install_log_forwarder
+  install_log_forwarder = var.datadog_integration.forward_logs
   tags                  = local.tags
 }

--- a/modules/avm/datadog.tf
+++ b/modules/avm/datadog.tf
@@ -2,7 +2,7 @@ module "datadog" {
   count                 = var.datadog_integration.enabled == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
   providers             = { aws = aws.managed_by_inception }
-  api_key               = var.datadog_api_key
+  api_key               = var.datadog_integration.api_key
   install_log_forwarder = var.datadog_integration.forward_logs
   tags                  = local.tags
 }

--- a/modules/avm/datadog.tf
+++ b/modules/avm/datadog.tf
@@ -1,0 +1,8 @@
+module "datadog" {
+  count                 = var.datadog_integration == true ? 1 : 0
+  providers             = { aws = aws.managed_by_inception }
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"
+  api_key               = var.datadog_api_key
+  install_log_forwarder = var.datadog_install_log_forwarder
+  tags                  = local.tags
+}

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,15 +1,11 @@
-variable "datadog_api_key" {
-  type        = string
-  default     = null
-  description = "Datadog API key"
-}
-
 variable "datadog_integration" {
   type = object({
+    api_key      = string
     enabled      = bool
     forward_logs = bool
   })
   default = {
+    api_key      = null
     enabled      = false
     forward_logs = false
   }

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -4,16 +4,16 @@ variable "datadog_api_key" {
   description = "Datadog API key"
 }
 
-variable "datadog_install_log_forwarder" {
-  type        = bool
-  default     = false
-  description = "Set to true to install Datadog AWS Log Forwarder"
-}
-
 variable "datadog_integration" {
-  type        = bool
-  default     = false
-  description = "Whether the Datadog integration should be enabled or not"
+  type = object({
+    enabled      = bool
+    forward_logs = bool
+  })
+  default = {
+    enabled      = false
+    forward_logs = false
+  }
+  description = "Configuration for Datadog Integration"
 }
 
 variable "defaults" {

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,3 +1,21 @@
+variable "datadog_api_key" {
+  type        = string
+  default     = null
+  description = "Datadog API key"
+}
+
+variable "datadog_install_log_forwarder" {
+  type        = bool
+  default     = false
+  description = "Set to true to install Datadog AWS Log Forwarder"
+}
+
+variable "datadog_integration" {
+  type        = bool
+  default     = false
+  description = "Whether the Datadog integration should be enabled or not"
+}
+
 variable "defaults" {
   type = object({
     account_prefix         = string

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,15 +1,11 @@
-variable "datadog_integration" {
+variable "datadog" {
   type = object({
-    api_key      = string
-    enabled      = bool
-    forward_logs = bool
+    api_key               = string
+    enable_integration    = bool
+    install_log_forwarder = bool
   })
-  default = {
-    api_key      = null
-    enabled      = false
-    forward_logs = false
-  }
-  description = "Configuration for Datadog Integration"
+  default     = null
+  description = "Datadog integration options"
 }
 
 variable "defaults" {

--- a/modules/avm/versions.tf
+++ b/modules/avm/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.7.0"
     }
+    datadog = {
+      source  = "datadog/datadog"
+      version = "~> 2.14"
+    }
     github = {
       source  = "hashicorp/github"
       version = "~> 3.1.0"

--- a/variables.tf
+++ b/variables.tf
@@ -28,38 +28,14 @@ variable "control_tower_account_ids" {
   description = "Control Tower core account IDs"
 }
 
-variable "datadog_integration" {
+variable "datadog" {
   type = object({
-    api_key = string
-    audit = object({
-      enabled      = bool
-      forward_logs = bool
-    })
-    logging = object({
-      enabled      = bool
-      forward_logs = bool
-    })
-    master = object({
-      enabled      = bool
-      forward_logs = bool
-    })
+    api_key               = string
+    enable_integration    = bool
+    install_log_forwarder = bool
   })
-  default = {
-    api_key = null
-    audit = {
-      enabled      = false
-      forward_logs = false
-    }
-    logging = {
-      enabled      = false
-      forward_logs = false
-    }
-    master = {
-      enabled      = false
-      forward_logs = false
-    }
-  }
-  description = "Configuration for Datadog Integration"
+  default     = null
+  description = "Datadog integration options for the core accounts"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -28,14 +28,9 @@ variable "control_tower_account_ids" {
   description = "Control Tower core account IDs"
 }
 
-variable "datadog_api_key" {
-  type        = string
-  default     = null
-  description = "Datadog API key"
-}
-
 variable "datadog_integration" {
   type = object({
+    api_key = string
     audit = object({
       enabled      = bool
       forward_logs = bool
@@ -50,6 +45,7 @@ variable "datadog_integration" {
     })
   })
   default = {
+    api_key = null
     audit = {
       enabled      = false
       forward_logs = false

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,32 @@ variable "control_tower_account_ids" {
   description = "Control Tower core account IDs"
 }
 
+variable "datadog_api_key" {
+  type        = string
+  default     = null
+  description = "Datadog API key"
+}
+
+variable "datadog_install_log_forwarder" {
+  type = object({
+    audit   = bool
+    logging = bool
+    master  = bool
+  })
+  default = {
+    audit   = false
+    logging = false
+    master  = false
+  }
+  description = "Set to true to install Datadog AWS Log Forwarder for each of the core accounts"
+}
+
+variable "datadog_integration" {
+  type        = bool
+  default     = false
+  description = "Whether the Datadog integration should be enabled or not"
+}
+
 variable "tags" {
   type        = map
   description = "Map of tags"

--- a/variables.tf
+++ b/variables.tf
@@ -34,24 +34,36 @@ variable "datadog_api_key" {
   description = "Datadog API key"
 }
 
-variable "datadog_install_log_forwarder" {
+variable "datadog_integration" {
   type = object({
-    audit   = bool
-    logging = bool
-    master  = bool
+    audit = object({
+      enabled      = bool
+      forward_logs = bool
+    })
+    logging = object({
+      enabled      = bool
+      forward_logs = bool
+    })
+    master = object({
+      enabled      = bool
+      forward_logs = bool
+    })
   })
   default = {
-    audit   = false
-    logging = false
-    master  = false
+    audit = {
+      enabled      = false
+      forward_logs = false
+    }
+    logging = {
+      enabled      = false
+      forward_logs = false
+    }
+    master = {
+      enabled      = false
+      forward_logs = false
+    }
   }
-  description = "Set to true to install Datadog AWS Log Forwarder for each of the core accounts"
-}
-
-variable "datadog_integration" {
-  type        = bool
-  default     = false
-  description = "Whether the Datadog integration should be enabled or not"
+  description = "Configuration for Datadog Integration"
 }
 
 variable "tags" {


### PR DESCRIPTION
This change adds support for the AWS-Datadog integration.

By using the variable `datadog_integration`, the integration can be optionally enabled. If enabled at the landing zone level, the integration will be provisioned for all core accounts. Forwarding logs can be controlled in a per account basis.

For the `avm` module, the same `datadog_integration` variable exists, allowing the integration to be enabled only where necessary. The same goes for log forwarding which can be enabled via the variable `datadog_install_log_forwarder`.