### PR TITLE
Enables AWS Config in the master account

### DIFF
--- a/audit.tf
+++ b/audit.tf
@@ -1,5 +1,3 @@
-data "aws_organizations_organization" "default" {}
-
 provider "aws" {
   alias = "audit"
 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+data "aws_organizations_organization" "default" {}
+
+data "aws_region" "current" {}

--- a/files/iam/service_assume_role.json.tpl
+++ b/files/iam/service_assume_role.json.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "${service}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,52 @@ locals {
   )
 }
 
+resource "aws_config_configuration_recorder" "default" {
+  name     = "default"
+  role_arn = aws_iam_role.config_recorder.arn
+
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = true
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "default" {
+  name       = aws_config_configuration_recorder.default.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.default]
+}
+
+resource "aws_config_delivery_channel" "default" {
+  name           = "default"
+  s3_bucket_name = "aws-controltower-logs-${var.control_tower_account_ids.logging}-${data.aws_region.current.name}"
+  s3_key_prefix  = data.aws_organizations_organization.default.id
+  sns_topic_arn  = "arn:aws:sns:${data.aws_region.current.name}:${var.control_tower_account_ids.audit}:aws-controltower-AllConfigNotifications"
+  depends_on     = [aws_config_configuration_recorder.default]
+}
+
 resource "aws_config_organization_managed_rule" "default" {
   for_each        = toset(local.aws_config_rules)
   name            = each.value
   rule_identifier = each.value
+}
+
+resource "aws_iam_role" "config_recorder" {
+  name = "LandingZone-ConfigRecorderRole"
+
+  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {
+    service = "config.amazonaws.com"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "config_recorder_read_only" {
+  role       = aws_iam_role.config_recorder.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
+  role       = aws_iam_role.config_recorder.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }
 
 module "datadog_master" {


### PR DESCRIPTION
AWS Control Tower doesn't enable AWS Config by default in master account. This change adds the necessary Config resources to enable it so that all `aws_config_organization_managed_rule` can be properly deployed in all accounts in the Organization.