### PR TITLE
Adds support for optional AWS Config Aggregate Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | Name | Version |
 |------|---------|
 | aws | ~> 3.7.0 |
+| aws.audit | ~> 3.7.0 |
+| aws.logging | ~> 3.7.0 |
 | okta | ~> 3.0 |
 
 ## Inputs
@@ -53,7 +55,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
-| aws\_config\_rules | List of managed AWS Config Rule identifiers that should be deployed across the organization | `list` | `[]` | no |
+| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>    rule_identifiers      = list(string)<br>  })</pre> | `null` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,18 @@ Terraform module to setup and manage various components of the AWS Landing Zone.
 
 ## AWS Config Rules
 
-This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed to the variable `aws_config_rules` like in the example below:
+This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed via the variable `aws_config` using the attribute `rule_identifiers`.
+
+If you would like to authorize another account to aggregate AWS Config data, the account ID and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_id` and `aggregator_regions` respectively.
+
+Example:
 
 ```hcl
-aws_config_rules = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
+aws_config = {
+  aggregator_account_id = "123456789012"
+  aggregator_regions    = ["eu-west-1"]
+  rule_identifiers      = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
+}
 ```
 
 ## Datadog Integration

--- a/audit.tf
+++ b/audit.tf
@@ -7,7 +7,7 @@ provider "aws" {
 }
 
 resource "aws_config_aggregate_authorization" "audit" {
-  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  for_each   = toset(try(var.aws_config.aggregator_regions, []))
   provider   = aws.audit
   account_id = var.aws_config.aggregator_account_id
   region     = each.value

--- a/audit.tf
+++ b/audit.tf
@@ -6,6 +6,13 @@ provider "aws" {
   }
 }
 
+resource "aws_config_aggregate_authorization" "audit" {
+  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  provider   = aws.audit
+  account_id = var.aws_config.aggregator_account_id
+  region     = each.value
+}
+
 module "datadog_audit" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"

--- a/logging.tf
+++ b/logging.tf
@@ -7,7 +7,7 @@ provider "aws" {
 }
 
 resource "aws_config_aggregate_authorization" "logging" {
-  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  for_each   = toset(try(var.aws_config.aggregator_regions, []))
   provider   = aws.logging
   account_id = var.aws_config.aggregator_account_id
   region     = each.value

--- a/logging.tf
+++ b/logging.tf
@@ -6,6 +6,13 @@ provider "aws" {
   }
 }
 
+resource "aws_config_aggregate_authorization" "logging" {
+  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  provider   = aws.logging
+  account_id = var.aws_config.aggregator_account_id
+  region     = each.value
+}
+
 module "datadog_logging" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "aws_config_aggregate_authorization" "master" {
-  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  for_each   = toset(try(var.aws_config.aggregator_regions, []))
   account_id = var.aws_config.aggregator_account_id
   region     = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   aws_config_rules = concat(
-    var.aws_config_rules,
+    try(var.aws_config.rule_identifiers, []),
     [
       "CLOUD_TRAIL_ENABLED",
       "ENCRYPTED_VOLUMES",
@@ -8,6 +8,12 @@ locals {
       "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
     ]
   )
+}
+
+resource "aws_config_aggregate_authorization" "master" {
+  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  account_id = var.aws_config.aggregator_account_id
+  region     = each.value
 }
 
 resource "aws_config_configuration_recorder" "default" {

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -2,6 +2,19 @@
 
 Terraform module to provision an AWS account with a TFE workspace backed by a VCS project.
 
+## AWS Config Rules
+
+If you would like to authorize another account to aggregate AWS Config data, the account ID and regions can be passed via the variable `aws_config` using the attributes `aggregator_account_id` and `aggregator_regions` respectively.
+
+Example:
+
+```hcl
+aws_config = {
+  aggregator_account_id = "123456789012"
+  aggregator_regions    = ["eu-west-1"]
+}
+```
+
 ## Datadog Integration
 
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -48,6 +48,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | tags | Map of tags | `map(string)` | n/a | yes |
+| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>  })</pre> | `null` | no |
 | datadog | Datadog integration options | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 resource "aws_config_aggregate_authorization" "default" {
-  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  for_each   = toset(try(var.aws_config.aggregator_regions, []))
   provider   = aws.managed_by_inception
   account_id = var.aws_config.aggregator_account_id
   region     = each.value

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -26,6 +26,13 @@ provider "aws" {
   }
 }
 
+resource "aws_config_aggregate_authorization" "default" {
+  for_each   = try(var.aws_config.aggregator_account_id, null) != null ? toset(var.aws_config.aggregator_regions) : []
+  provider   = aws.managed_by_inception
+  account_id = var.aws_config.aggregator_account_id
+  region     = each.value
+}
+
 resource "aws_iam_account_alias" "alias" {
   provider      = aws.managed_by_inception
   account_alias = local.prefixed_name

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,3 +1,12 @@
+variable "aws_config" {
+  type = object({
+    aggregator_account_id = string
+    aggregator_regions    = list(string)
+  })
+  default     = null
+  description = "AWS Config settings"
+}
+
 variable "datadog" {
   type = object({
     api_key               = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,11 @@
-variable "aws_config_rules" {
-  type        = list
-  default     = []
-  description = "List of managed AWS Config Rule identifiers that should be deployed across the organization"
+variable "aws_config" {
+  type = object({
+    aggregator_account_id = string
+    aggregator_regions    = list(string)
+    rule_identifiers      = list(string)
+  })
+  default     = null
+  description = "AWS Config settings"
 }
 
 variable "aws_okta_group_ids" {


### PR DESCRIPTION
According to instruction from the Cloud Acceleration Team (CAT), all accounts should allow our security team account access to aggregate AWS Config compliance and configuration data.

This change introduces support for that requirement. To be able to set the default regions required by the security team (i.e. `eu-central-1` and `eu-west-1`), the configuration is set via two variables instead of a single object variable.