### PR TITLE
Adds optional SCP to restrict allowed regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ aws_allowed_regions = ["eu-west-1"]
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
+| aws\_allowed\_regions | List of AWS regions allowed to be used | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>    rule_identifiers      = list(string)<br>  })</pre> | `null` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ provider "datadog" {
 
 This should prevent the provider from asking you for a Datadog API Key and allow the module to be provisioned without the integration resources.
 
+## Restricting AWS Regions
+
+If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_allowed_regions`. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.
+
+Example:
+
+```hcl
+aws_allowed_regions = ["eu-west-1"]
+```
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ aws_allowed_regions = ["eu-west-1"]
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
-| aws\_allowed\_regions | List of AWS regions allowed to be used | `list(string)` | `null` | no |
+| aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>    rule_identifiers      = list(string)<br>  })</pre> | `null` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |

--- a/files/organizations/allowed_regions_scp.json.tpl
+++ b/files/organizations/allowed_regions_scp.json.tpl
@@ -1,0 +1,56 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenyAllOutsideAllowedList",
+            "Effect": "Deny",
+            "NotAction": [
+                "a4b:*",
+                "acm:*",
+                "aws-marketplace-management:*",
+                "aws-marketplace:*",
+                "aws-portal:*",
+                "awsbillingconsole:*",
+                "budgets:*",
+                "ce:*",
+                "chime:*",
+                "cloudfront:*",
+                "config:*",
+                "cur:*",
+                "directconnect:*",
+                "ec2:DescribeRegions",
+                "ec2:DescribeTransitGateways",
+                "ec2:DescribeVpnGateways",
+                "fms:*",
+                "globalaccelerator:*",
+                "health:*",
+                "iam:*",
+                "importexport:*",
+                "kms:*",
+                "mobileanalytics:*",
+                "networkmanager:*",
+                "organizations:*",
+                "pricing:*",
+                "route53:*",
+                "route53domains:*",
+                "s3:GetAccountPublic*",
+                "s3:ListAllMyBuckets",
+                "s3:PutAccountPublic*",
+                "shield:*",
+                "sts:*",
+                "support:*",
+                "trustedadvisor:*",
+                "waf-regional:*",
+                "waf:*",
+                "wafv2:*",
+                "wellarchitected:*"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringNotEquals": {
+                    "aws:RequestedRegion": ${allowed_regions}
+                }
+            }
+        }
+    ]
+}

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,21 @@ resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }
 
+resource "aws_organizations_policy" "allowed_regions" {
+  count = var.aws_allowed_regions != null ? 1 : 0
+  name  = "LandingZone-AllowedRegions"
+
+  content = templatefile("${path.module}/files/organizations/allowed_regions_scp.json.tpl", {
+    allowed_regions = jsonencode(var.aws_allowed_regions)
+  })
+}
+
+resource "aws_organizations_policy_attachment" "allowed_regions" {
+  count     = var.aws_allowed_regions != null ? 1 : 0
+  policy_id = aws_organizations_policy.allowed_regions[0].id
+  target_id = data.aws_organizations_organization.default.roots[0].id
+}
+
 module "datadog_master" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.2"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "aws_allowed_regions" {
+  type        = list(string)
+  default     = null
+  description = "List of AWS regions allowed to be used"
+}
+
 variable "aws_config" {
   type = object({
     aggregator_account_id = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_allowed_regions" {
   type        = list(string)
   default     = null
-  description = "List of AWS regions allowed to be used"
+  description = "List of allowed AWS regions"
 }
 
 variable "aws_config" {


### PR DESCRIPTION
There are use cases where only specific AWS Regions should be available for use (e.g. no resources outside the EU). 

In order to make sure that no resources can be accidentally deployed in regions that shouldn't be used, this change adds an optional [SCP designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) that limits the access to a specific list of allowed regions. Global services are exempt from this restriction.

The optional SCP is deployed only if `aws_allowed_regions` is set and it's attached to the root of the AWS Organization.