### PR TITLE
Adds support for AWS GuardDuty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+* Add support for AWS GuardDuty ([#12](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/12))
 * Fix multiple bugs in unreleased features ([#23](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/23))
 * Modify terraform-aws-mcaf-workspace version to 0.3.0 in the avm module, in order to prevent github error ([#22](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/22))
 * Add filter to create rules only for the right identities ([#21](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/21))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+ENHANCEMENTS
+
 * Add support for AWS GuardDuty ([#12](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/12))
-* Fix multiple bugs in unreleased features ([#23](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/23))
 * Modify terraform-aws-mcaf-workspace version to 0.3.0 in the avm module, in order to prevent github error ([#22](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/22))
-* Add filter to create rules only for the right identities ([#21](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/21))
-* Fix errors when monitor_iam_access is null ([#19](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/19))
-* Add condition to audit AWS Config Aggregate Auth ([#20](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/20))
 * Add KMS Key in the Audit account ([#18](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/18))
 * Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))
 * Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
 * Add support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
 * Make account and email names more flexible. ([#17](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/17))
+
+BUG FIXES
+
+* Fix multiple bugs in unreleased features ([#23](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/23))
+* Add filter to create rules only for the right identities ([#21](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/21))
+* Fix errors when monitor_iam_access is null ([#19](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/19))
+* Add condition to audit AWS Config Aggregate Auth ([#20](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/20))
 
 ## 0.1.0 (2020-11-16)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ aws_config = {
 
 This module supports enabling GuardDuty at the organization level which means that all new accounts that are created in, or added to, the organization are added as a member accounts of the `audit` account GuardDuty detector.
 
-This feature can be controlled via the variable `aws_guardduty` and is enabled by default.
+This feature can be controlled via the `aws_guardduty` variable and is enabled by default.
 
 Note: In case you are migrating an existing AWS organization to this module, all existing accounts except for the `master` and `logging` accounts have to be enabled like explained [here](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html#guardduty_add_orgs_accounts).
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ aws_config = {
 }
 ```
 
+## AWS GuardDuty
+
+This module supports enabling GuardDuty at the organization level which means that all new accounts that are created in, or added to, the organization are added as a member accounts of the `audit` account GuardDuty detector.
+
+This feature can be controlled via the variable `aws_guardduty` and is enabled by default.
+
+Note: In case you are migrating an existing AWS organization to this module, all existing accounts except for the `master` and `logging` accounts have to be enabled like explained [here](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html#guardduty_add_orgs_accounts).
+
 ## Datadog Integration
 
 This module supports an optional Datadog-AWS integration. This integration makes it easier for you to forward metrics and logs from your AWS account to Datadog.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ aws_allowed_regions = ["eu-west-1"]
 | tags | Map of tags | `map` | n/a | yes |
 | aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
+| aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |

--- a/audit.tf
+++ b/audit.tf
@@ -29,7 +29,10 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access_audit" {
     userIdentity = jsonencode(each.value.userIdentity)
   })
 
-  depends_on = [data.aws_iam_role.monitor_iam_access_audit, data.aws_iam_user.monitor_iam_access_audit]
+  depends_on = [
+    data.aws_iam_role.monitor_iam_access_audit,
+    data.aws_iam_user.monitor_iam_access_audit
+  ]
 }
 
 resource "aws_cloudwatch_event_target" "monitor_iam_access_audit" {
@@ -99,8 +102,8 @@ resource "aws_guardduty_member" "logging" {
   detector_id = aws_guardduty_detector.audit[0].id
   email       = local.aws_account_emails[aws_guardduty_detector.logging[0].account_id]
   invite      = true
+  depends_on  = [aws_guardduty_organization_admin_account.audit]
 
-  depends_on = [aws_guardduty_organization_admin_account.audit]
   lifecycle {
     ignore_changes = [email]
   }
@@ -113,8 +116,8 @@ resource "aws_guardduty_member" "master" {
   detector_id = aws_guardduty_detector.audit[0].id
   email       = local.aws_account_emails[aws_guardduty_detector.master[0].account_id]
   invite      = true
+  depends_on  = [aws_guardduty_organization_admin_account.audit]
 
-  depends_on = [aws_guardduty_organization_admin_account.audit]
   lifecycle {
     ignore_changes = [email]
   }
@@ -125,8 +128,7 @@ resource "aws_guardduty_organization_configuration" "default" {
   provider    = aws.audit
   auto_enable = true
   detector_id = aws_guardduty_detector.audit[0].id
-
-  depends_on = [aws_guardduty_organization_admin_account.audit]
+  depends_on  = [aws_guardduty_organization_admin_account.audit]
 }
 
 module "datadog_audit" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  aws_account_emails = { for account in data.aws_organizations_organization.default.accounts : account.id => account.email }
   aws_config_aggregators = flatten([
     for account in toset(try(var.aws_config.aggregator_account_ids, [])) : [
       for region in toset(try(var.aws_config.aggregator_regions, [])) : {

--- a/logging.tf
+++ b/logging.tf
@@ -16,17 +16,19 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access_logging" {
     userIdentity = jsonencode(each.value.userIdentity)
   })
 
-  depends_on = [data.aws_iam_role.monitor_iam_access_logging, data.aws_iam_user.monitor_iam_access_logging]
+  depends_on = [
+    data.aws_iam_role.monitor_iam_access_logging,
+    data.aws_iam_user.monitor_iam_access_logging
+  ]
 }
 
 resource "aws_cloudwatch_event_target" "monitor_iam_access_logging" {
-  for_each  = aws_cloudwatch_event_rule.monitor_iam_access_logging
-  provider  = aws.logging
-  arn       = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
-  role_arn  = aws_iam_role.monitor_iam_access_logging.arn
-  rule      = each.value.name
-  target_id = "SendToAuditEventBus"
-
+  for_each   = aws_cloudwatch_event_rule.monitor_iam_access_logging
+  provider   = aws.logging
+  arn        = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
+  role_arn   = aws_iam_role.monitor_iam_access_logging.arn
+  rule       = each.value.name
+  target_id  = "SendToAuditEventBus"
   depends_on = [aws_cloudwatch_event_permission.organization_access_audit]
 }
 

--- a/logging.tf
+++ b/logging.tf
@@ -37,6 +37,11 @@ resource "aws_config_aggregate_authorization" "logging" {
   region     = each.value.region
 }
 
+resource "aws_guardduty_detector" "logging" {
+  count    = var.aws_guardduty == true ? 1 : 0
+  provider = aws.logging
+}
+
 resource "aws_iam_role" "monitor_iam_access_logging" {
   provider           = aws.logging
   name               = "LandingZone-MonitorIAMAccess"

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,15 @@ resource "aws_config_configuration_recorder" "default" {
   }
 }
 
+resource "aws_guardduty_detector" "master" {
+  count = var.aws_guardduty == true ? 1 : 0
+}
+
+resource "aws_guardduty_organization_admin_account" "audit" {
+  count            = var.aws_guardduty == true ? 1 : 0
+  admin_account_id = var.control_tower_account_ids.audit
+}
+
 resource "aws_config_configuration_recorder_status" "default" {
   name       = aws_config_configuration_recorder.default.name
   is_enabled = true

--- a/main.tf
+++ b/main.tf
@@ -7,16 +7,18 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access_master" {
     userIdentity = jsonencode(each.value.userIdentity)
   })
 
-  depends_on = [data.aws_iam_role.monitor_iam_access_master, data.aws_iam_user.monitor_iam_access_master]
+  depends_on = [
+    data.aws_iam_role.monitor_iam_access_master,
+    data.aws_iam_user.monitor_iam_access_master
+  ]
 }
 
 resource "aws_cloudwatch_event_target" "monitor_iam_access_master" {
-  for_each  = aws_cloudwatch_event_rule.monitor_iam_access_master
-  arn       = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
-  role_arn  = aws_iam_role.monitor_iam_access_master.arn
-  rule      = each.value.name
-  target_id = "SendToAuditEventBus"
-
+  for_each   = aws_cloudwatch_event_rule.monitor_iam_access_master
+  arn        = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
+  role_arn   = aws_iam_role.monitor_iam_access_master.arn
+  rule       = each.value.name
+  target_id  = "SendToAuditEventBus"
   depends_on = [aws_cloudwatch_event_permission.organization_access_audit]
 }
 

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -95,7 +95,10 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access" {
     userIdentity = jsonencode(each.value)
   })
 
-  depends_on = [data.aws_iam_role.monitor_iam_access, data.aws_iam_user.monitor_iam_access]
+  depends_on = [
+    data.aws_iam_role.monitor_iam_access,
+    data.aws_iam_user.monitor_iam_access
+  ]
 }
 
 resource "aws_cloudwatch_event_target" "monitor_iam_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "aws_config" {
   description = "AWS Config settings"
 }
 
+variable "aws_guardduty" {
+  type        = bool
+  default     = true
+  description = "Whether AWS GuardDuty should be enabled"
+}
+
 variable "aws_okta_group_ids" {
   type        = list
   default     = []


### PR DESCRIPTION
This change adds optional support for GuardDuty. The functionality can be controlled via the boolean variable `aws_guardduty` and is enabled by default.

The approach takes advantage of the integration between GuardDuty and AWS Organizations to automate the invite of member accounts. This is accomplished by using [this Terraform resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration). For more details about how the integration works, take a look at [this link](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html).

Enabling GuardDuty this way has some pros and cons.

**Pros:**
- Every new account in the organization will have GuardDuty enabled automatically and will be added to the Audit account GuardDuty overview.
- It avoids having to pass an extra `provider` to the `avm` module. This comes from the fact that to be able to invite a new account, the [`aws_guardduty_member` resource has to be associated with the `Audit` provider  and the `aws_guardduty_invite_accepter` to the new account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_invite_accepter). This means that if we would like to add GuardDuty to the `avm` module as we did with SecurityHub, we would have to always pass an extra provider `aws.audit` even when we don't want to use GuardDuty.

**Cons:**
- When migrating an existing AWS Organization to this module, all existing non-core accounts have to be added as explained [here](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html#guardduty_add_orgs_accounts)
- We don't have a reusable GuardDuty module like we have for Security Hub. However, this comes back to the extra module requirement explained in the "Pros" list.
- We can't disable GuardDuty for specific accounts. It will be automatically enabled for all accounts in the organization.

