### PR TITLE
Adds support for defining specific account name for AWS Service Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
-* Adds support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
+* Add support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
 
 ## 0.1.0 (2020-11-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Adds support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
+
 ## 0.1.0 (2020-11-16)
 
 * Adds optional SCP to restrict allowed regions ([#11](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/11))

--- a/README.md
+++ b/README.md
@@ -83,5 +83,6 @@ aws_allowed_regions = ["eu-west-1"]
 | Name | Description |
 |------|-------------|
 | kms\_key\_arn | ARN of KMS key for SSM encryption |
+| kms\_key\_id | ID of KMS key for SSM encryption |
 
 <!--- END_TF_DOCS --->

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -61,6 +61,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | tags | Map of tags | `map(string)` | n/a | yes |
+| account\_name | Name of the AWS Service Catalog provisioned account (overrides computed name from the `name` variable) | `string` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>  })</pre> | `null` | no |
 | datadog | Datadog integration options | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | email | Email address of the account | `string` | `null` | no |

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -8,7 +8,7 @@ locals {
 
 module "account" {
   source                   = "github.com/schubergphilis/terraform-aws-mcaf-account?ref=v0.3.0"
-  account                  = local.name
+  account                  = coalesce(var.account_name, local.name)
   email                    = local.email
   organizational_unit      = local.organizational_unit
   provisioned_product_name = var.provisioned_product_name

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,3 +1,9 @@
+variable "account_name" {
+  type        = string
+  default     = null
+  description = "Name of the AWS Service Catalog provisioned account (overrides computed name from the `name` variable)"
+}
+
 variable "aws_config" {
   type = object({
     aggregator_account_id = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "kms_key_arn" {
   description = "ARN of KMS key for SSM encryption"
   value       = module.kms_key.arn
 }
+
+output "kms_key_id" {
+  description = "ID of KMS key for SSM encryption"
+  value       = module.kms_key.id
+}


### PR DESCRIPTION
The current approach to define the account name in the `avm` module is not flexible which blocks migrating existing organizations to this module.

This PR proposes the following changes:
- Adding a variable called `prefixed_name` that indicates whether the account name should be prefixed or not instead of always adding the prefix (default value is `true`). We already have use cases of accounts that were provisioned via Control Tower with a non-prefixed name. So this would allow us to migrate those accounts to the `avm` module without issues.
- Only appending the environment to the account name in case it's different than `prod`.
- Standardizing the account alias and the name passed to the terraform-aws-mcaf-account module
- Adds an extra output related to the KMS key created in the master account