### PR TITLE
Adds support for multiple AWS Config Aggregators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
-* Adds support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
+* Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
 
 ## 0.1.0 (2020-11-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Adds support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
+
 ## 0.1.0 (2020-11-16)
 
 * Adds optional SCP to restrict allowed regions ([#11](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/11))

--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@ Terraform module to setup and manage various components of the AWS Landing Zone.
 
 This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed via the variable `aws_config` using the attribute `rule_identifiers`.
 
-If you would like to authorize another account to aggregate AWS Config data, the account ID and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_id` and `aggregator_regions` respectively.
+If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively. 
+
+NOTE: The `audit` account will be automatically authorized to aggregate AWS Config data from the other 2 core acccounts in the following regions: `eu-central-1` and `eu-west-1`.
 
 Example:
 
 ```hcl
 aws_config = {
-  aggregator_account_id = "123456789012"
-  aggregator_regions    = ["eu-west-1"]
-  rule_identifiers      = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
+  aggregator_account_ids = ["123456789012"]
+  aggregator_regions     = ["eu-west-1"]
+  rule_identifiers       = ["ACCESS_KEYS_ROTATED", "ALB_WAF_ENABLED"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ aws_allowed_regions = ["eu-west-1"]
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
 | aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
-| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>    rule_identifiers      = list(string)<br>  })</pre> | `null` | no |
+| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  aws_config_aggregators = flatten([
+    for account in toset(concat(try(var.aws_config.aggregator_account_ids, []), [var.control_tower_account_ids.audit])) : [
+      for region in toset(concat(try(var.aws_config.aggregator_regions, []), ["eu-central-1", "eu-west-1"])) : {
+        account_id = account
+        region     = region
+      }
+    ]
+  ])
+  aws_config_rules = concat(
+    try(var.aws_config.rule_identifiers, []),
+    [
+      "CLOUD_TRAIL_ENABLED",
+      "ENCRYPTED_VOLUMES",
+      "ROOT_ACCOUNT_MFA_ENABLED",
+      "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+    ]
+  )
+}

--- a/logging.tf
+++ b/logging.tf
@@ -7,10 +7,10 @@ provider "aws" {
 }
 
 resource "aws_config_aggregate_authorization" "logging" {
-  for_each   = toset(try(var.aws_config.aggregator_regions, []))
+  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
   provider   = aws.logging
-  account_id = var.aws_config.aggregator_account_id
-  region     = each.value
+  account_id = each.value.account_id
+  region     = each.value.region
 }
 
 module "datadog_logging" {

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,7 @@
-locals {
-  aws_config_rules = concat(
-    try(var.aws_config.rule_identifiers, []),
-    [
-      "CLOUD_TRAIL_ENABLED",
-      "ENCRYPTED_VOLUMES",
-      "ROOT_ACCOUNT_MFA_ENABLED",
-      "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
-    ]
-  )
-}
-
 resource "aws_config_aggregate_authorization" "master" {
-  for_each   = toset(try(var.aws_config.aggregator_regions, []))
-  account_id = var.aws_config.aggregator_account_id
-  region     = each.value
+  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
+  account_id = each.value.account_id
+  region     = each.value.region
 }
 
 resource "aws_config_configuration_recorder" "default" {

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -4,14 +4,14 @@ Terraform module to provision an AWS account with a TFE workspace backed by a VC
 
 ## AWS Config Rules
 
-If you would like to authorize another account to aggregate AWS Config data, the account ID and regions can be passed via the variable `aws_config` using the attributes `aggregator_account_id` and `aggregator_regions` respectively.
+If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively.
 
 Example:
 
 ```hcl
 aws_config = {
-  aggregator_account_id = "123456789012"
-  aggregator_regions    = ["eu-west-1"]
+  aggregator_account_ids = ["123456789012"]
+  aggregator_regions     = ["eu-west-1"]
 }
 ```
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -61,7 +61,7 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | tags | Map of tags | `map(string)` | n/a | yes |
-| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_id = string<br>    aggregator_regions    = list(string)<br>  })</pre> | `null` | no |
+| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | datadog | Datadog integration options | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_config" {
   type = object({
-    aggregator_account_id = string
-    aggregator_regions    = list(string)
+    aggregator_account_ids = list(string)
+    aggregator_regions     = list(string)
   })
   default     = null
   description = "AWS Config settings"

--- a/variables.tf
+++ b/variables.tf
@@ -6,9 +6,8 @@ variable "aws_allowed_regions" {
 
 variable "aws_config" {
   type = object({
-    aggregator_account_id = string
-    aggregator_regions    = list(string)
-    rule_identifiers      = list(string)
+    aggregator_account_ids = list(string)
+    aggregator_regions     = list(string)
   })
   default     = null
   description = "AWS Config settings"


### PR DESCRIPTION
This PR adds support for providing multiple AWS Config Aggregator account IDs. 

We would like to be able to allow not only a central security account to aggregate AWS Config data but also the `audit` account of the Landing Zone itself. The current implementation allows only for one aggregator account ID.

For the core accounts, this changes adds the `audit` account and the regions `eu-central-1` and `eu-west-1` as default values to make sure that at least data from all 3 core accounts can be seen in the `audit` account.