### PR TITLE
Adds support for monitoring IAM access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+* Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))
 * Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
 * Add support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ aws_allowed_regions = ["eu-west-1"]
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
+| monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
 
 ## Outputs
 
@@ -114,5 +115,6 @@ aws_allowed_regions = ["eu-west-1"]
 |------|-------------|
 | kms\_key\_arn | ARN of KMS key for SSM encryption |
 | kms\_key\_id | ID of KMS key for SSM encryption |
+| monitor\_iam\_access\_sns\_topic\_arn | ARN of the SNS Topic in the Audit account for IAM access monitoring notifications |
 
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ provider "datadog" {
 
 This should prevent the provider from asking you for a Datadog API Key and allow the module to be provisioned without the integration resources.
 
+## Monitoring IAM Access
+
+This module automatically monitors and notifies all activities performed by the `root` user of all core accounts. All notifications will be sent to the SNS Topic `LandingZone-MonitorIAMAccess` in the `audit` account.
+
+In case you would like to monitor other users or roles, a list can be passed using the variable `monitor_iam_access`. All objects in the list should have the attributes `account`, `name` and `type`. 
+
+The allowed values are:
+
+- `account`: `audit`, `logging` or `master`
+- `name`: the name of the IAM Role or the IAM User
+- `type`: `AssumedRole` or `IAMUser` 
+
+For more details regarding identities, please check [this link](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html).
+
+NOTE: Data Sources will be used to make sure that the identities provided actually exist in each account to avoid monitoring non-existent resources. In case an invalid identity is provided, a `NoSuchEntity` error will be thrown. 
+
+Example:
+
+```hcl
+monitor_iam_access = [
+  {
+    account = "master"
+    name    = "AWSReservedSSO_AWSAdministratorAccess_123abc"
+    type    = "AssumedRole"
+  }
+]
+```
+
 ## Restricting AWS Regions
 
 If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_allowed_regions`. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.

--- a/audit.tf
+++ b/audit.tf
@@ -6,6 +6,27 @@ provider "aws" {
   }
 }
 
+resource "aws_cloudwatch_event_rule" "monitor_iam_access_audit" {
+  for_each    = local.monitor_iam_access
+  provider    = aws.audit
+  name        = substr("LandingZone-MonitorIAMAccess-${each.key}", 0, 64)
+  description = "Monitors IAM access for ${each.key}"
+
+  event_pattern = templatefile("${path.module}/files/event_bridge/monitor_iam_access.json.tpl", {
+    userIdentity = jsonencode(each.value)
+  })
+
+  depends_on = [data.aws_iam_role.monitor_iam_access_audit, data.aws_iam_user.monitor_iam_access_audit]
+}
+
+resource "aws_cloudwatch_event_target" "monitor_iam_access_audit" {
+  for_each  = aws_cloudwatch_event_rule.monitor_iam_access_audit
+  provider  = aws.audit
+  rule      = each.value.name
+  target_id = "SendToSNS"
+  arn       = aws_sns_topic.monitor_iam_access.arn
+}
+
 resource "aws_config_aggregate_authorization" "audit" {
   for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
   provider   = aws.audit
@@ -22,6 +43,15 @@ resource "aws_config_configuration_aggregator" "audit" {
     ]
     all_regions = true
   }
+}
+
+resource "aws_sns_topic" "monitor_iam_access" {
+  name = "LandingZone-MonitorIAMAccess"
+}
+
+resource "aws_sns_topic_policy" "monitor_iam_access" {
+  arn    = aws_sns_topic.monitor_iam_access.arn
+  policy = data.aws_iam_policy_document.monitor_iam_access_sns_topic_policy.json
 }
 
 module "datadog_audit" {

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,67 @@
+data "aws_iam_policy_document" "monitor_iam_access_sns_topic_policy" {
+  provider = aws.audit
+
+  statement {
+    effect  = "Allow"
+    actions = ["SNS:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+        data.aws_organizations_organization.default.id
+      ]
+    }
+
+    resources = [aws_sns_topic.monitor_iam_access.arn]
+  }
+}
+
+data "aws_iam_role" "monitor_iam_access_audit" {
+  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "audit"])
+  provider = aws.audit
+  name     = each.value
+}
+
+data "aws_iam_user" "monitor_iam_access_audit" {
+  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "audit"])
+  provider  = aws.audit
+  user_name = each.value
+}
+
+data "aws_iam_role" "monitor_iam_access_logging" {
+  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "logging"])
+  provider = aws.logging
+  name     = each.value
+}
+
+data "aws_iam_user" "monitor_iam_access_logging" {
+  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "logging"])
+  provider  = aws.logging
+  user_name = each.value
+}
+
+data "aws_iam_role" "monitor_iam_access_master" {
+  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "master"])
+  name     = each.value
+}
+
+data "aws_iam_user" "monitor_iam_access_master" {
+  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "master"])
+  user_name = each.value
+}
+
 data "aws_organizations_organization" "default" {}
 
 data "aws_region" "current" {}
+
+data "aws_sns_topic" "all_config_notifications" {
+  provider = aws.audit
+  name     = "aws-controltower-AllConfigNotifications"
+}

--- a/files/event_bridge/monitor_iam_access.json.tpl
+++ b/files/event_bridge/monitor_iam_access.json.tpl
@@ -1,0 +1,9 @@
+{
+    "detail-type": [
+      "AWS API Call via CloudTrail",
+      "AWS Console Sign In via CloudTrail"
+    ],
+    "detail": {
+      "userIdentity": ${userIdentity}
+    }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -16,4 +16,27 @@ locals {
       "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
     ]
   )
+  monitor_iam_access = merge(
+    {
+      for identity in try(var.monitor_iam_access, []) : identity.name => {
+        "type"     = [identity.type]
+        "userName" = identity.name
+      } if identity.type == "IAMUser"
+    },
+    {
+      for identity in try(var.monitor_iam_access, []) : identity.name => {
+        "type" = [identity.type]
+        "sessionContext" = {
+          "sessionIssuer" = {
+            "userName" = identity.name
+          }
+        }
+      } if identity.type == "AssumedRole"
+    },
+    {
+      "Root" = {
+        "type" = ["Root"]
+      }
+    }
+  )
 }

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -35,6 +35,32 @@ provider "datadog" {
 
 This should prevent the provider from asking you for a Datadog API Key and allow the module to be provisioned without the integration resources.
 
+## Monitoring IAM Access
+
+This module offers the capability of monitoring IAM activity of both users and roles. To enable this feature, you have to provide the ARN of the SNS Topic that should be notified in case any activity is detected.
+
+The topic ARN can be set using the attribute `sns_topic_arn` in the variable `monitor_iam_access`. In case the feature is enabled, the activity of the `root` user will be automatically monitored and reported.
+
+If you would like to monitor other users or roles, a list can be passed using the attribute `identities` in the variable `monitor_iam_access`. All objects in the list should have the attributes `name` and `type` where `name` is either the name of the IAM Role or the IAM User and `type` is either `AssumedRole` or `IAMUser`. 
+
+For more details regarding identities, please check [this link](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html).
+
+NOTE: Data Sources will be used to make sure that the identities provided actually exist in the account to avoid monitoring non-existent resources. In case an invalid identity is provided, a `NoSuchEntity` error will be thrown. 
+
+Example:
+
+```hcl
+monitor_iam_access = {
+  sns_topic_arn = aws_sns_topic.monitor_iam_access.arn
+  identities = [
+    {
+      name = "AWSReservedSSO_AWSAdministratorAccess_123abc"
+      type = "AssumedRole"
+    }
+  ]
+}
+```
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -93,6 +93,7 @@ monitor_iam_access = {
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |
+| monitor\_iam\_access | Object containing list of IAM Identities that should have their access monitored and the SNS Topic that should be notified | <pre>object({<br>    sns_topic_arn = string<br>    identities = list(object({<br>      name = string<br>      type = string<br>    }))<br>  })</pre> | `null` | no |
 | organizational\_unit | Organizational Unit to place account in | `string` | `null` | no |
 | provisioned\_product\_name | A custom name for the provisioned product | `string` | `null` | no |
 | region | The default region of the account | `string` | `"eu-west-1"` | no |

--- a/modules/avm/files/event_bridge/monitor_iam_access.json.tpl
+++ b/modules/avm/files/event_bridge/monitor_iam_access.json.tpl
@@ -1,0 +1,9 @@
+{
+    "detail-type": [
+      "AWS API Call via CloudTrail",
+      "AWS Console Sign In via CloudTrail"
+    ],
+    "detail": {
+      "userIdentity": ${userIdentity}
+    }
+}

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -74,6 +74,18 @@ variable "provisioned_product_name" {
   description = "A custom name for the provisioned product"
 }
 
+variable "monitor_iam_access" {
+  type = object({
+    sns_topic_arn = string
+    identities = list(object({
+      name = string
+      type = string
+    }))
+  })
+  default     = null
+  description = "Object containing list of IAM Identities that should have their access monitored and the SNS Topic that should be notified"
+}
+
 variable "region" {
   type        = string
   default     = "eu-west-1"

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "kms_key_id" {
   description = "ID of KMS key for SSM encryption"
   value       = module.kms_key.id
 }
+
+output "monitor_iam_access_sns_topic_arn" {
+  description = "ARN of the SNS Topic in the Audit account for IAM access monitoring notifications"
+  value       = aws_sns_topic.monitor_iam_access.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,23 @@ variable "datadog" {
   description = "Datadog integration options for the core accounts"
 }
 
+variable "monitor_iam_access" {
+  type = list(object({
+    account = string
+    name    = string
+    type    = string
+  }))
+  default     = null
+  description = "List of IAM Identities that should have their access monitored"
+
+  validation {
+    condition = length(setsubtract(toset([
+      for identity in var.monitor_iam_access : identity.account
+    ]), ["audit", "logging", "master"])) == 0
+    error_message = "Invalid account. The allowed values are \"audit\", \"logging\" or \"master\"."
+  }
+}
+
 variable "tags" {
   type        = map
   description = "Map of tags"


### PR DESCRIPTION
This PR adds the capability of monitoring the activity of the `root` user and any other IAM User or IAM Role.

The main purpose of this change is to monitor when users with privileged access interact with our accounts. The CloudWatch Rule pattern will look for both Console and API activity.

For the core accounts, the `root` user will be automatically monitored and all activities will be reported to the topic `LandingZone-MonitorIAMAccess` in the `audit` account.

For the `avm` created accounts, the monitoring is optional and can be enabled by passing the ARN of SNS Topic that should receive notifications. If enabled, the `root` user of the account will also be automatically monitored.