### PR TITLE
Make AVM naming more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 * Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))
 * Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
 * Add support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))
+* Make account and email names more flexible. ([#17](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/17))
 
 ## 0.1.0 (2020-11-16)
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -83,7 +83,7 @@ monitor_iam_access = {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| defaults | Default options for this module | <pre>object({<br>    account_prefix         = string<br>    github_organization    = string<br>    sso_email              = string<br>    terraform_organization = string<br>    terraform_version      = string<br>  })</pre> | n/a | yes |
+| defaults | Default options for this module | <pre>object({<br>    account_iam_prefix     = string<br>    email_prefix           = string<br>    github_organization    = string<br>    sso_email              = string<br>    terraform_organization = string<br>    terraform_version      = string<br>  })</pre> | n/a | yes |
 | name | Stack name | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | tags | Map of tags | `map(string)` | n/a | yes |

--- a/modules/avm/main.tf
+++ b/modules/avm/main.tf
@@ -7,10 +7,11 @@ locals {
       }
     ]
   ]) : []
+
   email               = var.email != null ? var.email : "${local.prefixed_email}@schubergphilis.com"
   name                = var.environment != null ? "${var.name}-${var.environment}" : var.name
-  prefixed_email      = "${var.defaults.account_prefix}-aws-${local.name}"
-  prefixed_name       = "${var.defaults.account_prefix}-${local.name}"
+  prefixed_email      = "${var.defaults.email_prefix}${local.name}"
+  prefixed_name       = "${var.defaults.account_iam_prefix}${local.name}"
   organizational_unit = var.organizational_unit != null ? var.organizational_unit : var.environment == "prod" ? "Production" : "Non-Production"
 
   monitor_iam_access = merge(

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -25,7 +25,8 @@ variable "datadog" {
 
 variable "defaults" {
   type = object({
-    account_prefix         = string
+    account_iam_prefix     = string
+    email_prefix           = string
     github_organization    = string
     sso_email              = string
     terraform_organization = string


### PR DESCRIPTION
As different teams use different conventions, we require a way to make IAM prefix and email prefix more flexible.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
