### PR TITLE
Add KMS Key in the Audit account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+* Add KMS Key in the Audit account ([#18](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/18))
 * Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))
 * Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))
 * Add support for defining specific account name for AWS Service Catalog ([#13](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/13))

--- a/audit.tf
+++ b/audit.tf
@@ -46,7 +46,8 @@ resource "aws_config_configuration_aggregator" "audit" {
 }
 
 resource "aws_sns_topic" "monitor_iam_access" {
-  name = "LandingZone-MonitorIAMAccess"
+  name              = "LandingZone-MonitorIAMAccess"
+  kms_master_key_id = module.kms_key_audit.id
 }
 
 resource "aws_sns_topic_policy" "monitor_iam_access" {
@@ -61,6 +62,14 @@ module "datadog_audit" {
   api_key               = try(var.datadog.api_key, null)
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
+}
+
+module "kms_key_audit" {
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.5"
+  name        = "audit"
+  description = "KMS key used for encrypting audit-related data"
+  policy      = file("${path.module}/files/kms/audit_key_policy.json")
+  tags        = var.tags
 }
 
 module "security_hub_audit" {

--- a/files/kms/audit_key_policy.json
+++ b/files/kms/audit_key_policy.json
@@ -1,0 +1,14 @@
+{
+  "Sid": "Allow_CloudWatch_for_CMK",
+  "Effect": "Allow",
+  "Principal": {
+    "Service":[
+      "events.amazonaws.com"
+    ]
+  },
+  "Action": [
+    "kms:Decrypt",
+    "kms:GenerateDataKey"
+  ],
+  "Resource": "*"
+}


### PR DESCRIPTION
In order to enable encryption in the SNS topic that will be handling IAM monitoring data, we would like to create a audit KMS key that can be used to encrypt all audit-related data in the `audit` account.