### PR TITLE
Fixes errors when monitor_iam_access is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+* Fix errors when monitor_iam_access is null ([#19](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/19))
 * Add condition to audit AWS Config Aggregate Auth ([#20](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/20))
 * Add KMS Key in the Audit account ([#18](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/18))
 * Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))

--- a/data.tf
+++ b/data.tf
@@ -24,36 +24,36 @@ data "aws_iam_policy_document" "monitor_iam_access_sns_topic_policy" {
 }
 
 data "aws_iam_role" "monitor_iam_access_audit" {
-  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "audit"])
+  for_each = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "audit"])
   provider = aws.audit
   name     = each.value
 }
 
 data "aws_iam_user" "monitor_iam_access_audit" {
-  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "audit"])
+  for_each  = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "audit"])
   provider  = aws.audit
   user_name = each.value
 }
 
 data "aws_iam_role" "monitor_iam_access_logging" {
-  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "logging"])
+  for_each = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "logging"])
   provider = aws.logging
   name     = each.value
 }
 
 data "aws_iam_user" "monitor_iam_access_logging" {
-  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "logging"])
+  for_each  = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "logging"])
   provider  = aws.logging
   user_name = each.value
 }
 
 data "aws_iam_role" "monitor_iam_access_master" {
-  for_each = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "master"])
+  for_each = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "AssumedRole" && identity.account == "master"])
   name     = each.value
 }
 
 data "aws_iam_user" "monitor_iam_access_master" {
-  for_each  = toset([for identity in try(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "master"])
+  for_each  = toset([for identity in coalesce(var.monitor_iam_access, []) : identity.name if identity.type == "IAMUser" && identity.account == "master"])
   user_name = each.value
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -18,13 +18,13 @@ locals {
   )
   monitor_iam_access = merge(
     {
-      for identity in try(var.monitor_iam_access, []) : identity.name => {
+      for identity in coalesce(var.monitor_iam_access, []) : identity.name => {
         "type"     = [identity.type]
         "userName" = identity.name
       } if identity.type == "IAMUser"
     },
     {
-      for identity in try(var.monitor_iam_access, []) : identity.name => {
+      for identity in coalesce(var.monitor_iam_access, []) : identity.name => {
         "type" = [identity.type]
         "sessionContext" = {
           "sessionIssuer" = {

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "monitor_iam_access" {
 
   validation {
     condition = length(setsubtract(toset([
-      for identity in var.monitor_iam_access : identity.account
+      for identity in coalesce(var.monitor_iam_access, []) : identity.account
     ]), ["audit", "logging", "master"])) == 0
     error_message = "Invalid account. The allowed values are \"audit\", \"logging\" or \"master\"."
   }


### PR DESCRIPTION
Since we are using `null` as default value for `monitor_iam_access`, we need to perform some checks perform trying to manipulate the list.

While testing other changes, I got some errors when not setting `monitor_iam_access`.

This PR changes fixes some wrong checks (i.e. `try` instead of `coalesce`) and adds a check to the variable validation.