### PR TITLE
Add condition to audit AWS Config Aggregate Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+* Add condition to audit AWS Config Aggregate Auth ([#20](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/20))
 * Add KMS Key in the Audit account ([#18](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/18))
 * Add support for monitoring IAM access ([#15](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/15))
 * Add support for multiple AWS Config Aggregators ([#14](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/14))

--- a/audit.tf
+++ b/audit.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_event_target" "monitor_iam_access_audit" {
 }
 
 resource "aws_config_aggregate_authorization" "audit" {
-  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
+  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator if aggregator.account_id != var.control_tower_account_ids.audit }
   provider   = aws.audit
   account_id = each.value.account_id
   region     = each.value.region


### PR DESCRIPTION
The condition prevents the `audit` account from creating an authorization for itself.