### PR TITLE
Bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+* Fix multiple bugs in unreleased features ([#23](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/23))
 * Modify terraform-aws-mcaf-workspace version to 0.3.0 in the avm module, in order to prevent github error ([#22](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/22))
 * Add filter to create rules only for the right identities ([#21](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/21))
 * Fix errors when monitor_iam_access is null ([#19](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/19))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module provisions by default a set of basic AWS Config Rules. In order to a
 
 If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively. 
 
-NOTE: The `audit` account will be automatically authorized to aggregate AWS Config data from the other 2 core acccounts in the following regions: `eu-central-1` and `eu-west-1`.
+NOTE: This module already authorizes the `audit` account to aggregate Config data from all other accounts in the organization, so there is no need to specify the `audit` account ID in the `aggregator_account_ids` list.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ aws_allowed_regions = ["eu-west-1"]
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | ~> 3.7.0 |
+| aws | ~> 3.16.0 |
 | okta | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.7.0 |
-| aws.audit | ~> 3.7.0 |
-| aws.logging | ~> 3.7.0 |
+| aws | ~> 3.16.0 |
+| aws.audit | ~> 3.16.0 |
+| aws.logging | ~> 3.16.0 |
 | okta | ~> 3.0 |
 
 ## Inputs

--- a/audit.tf
+++ b/audit.tf
@@ -67,10 +67,15 @@ module "datadog_audit" {
 
 module "kms_key_audit" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.5"
+  providers   = { aws = aws.audit }
   name        = "audit"
   description = "KMS key used for encrypting audit-related data"
-  policy      = file("${path.module}/files/kms/audit_key_policy.json")
   tags        = var.tags
+
+  policy = templatefile("${path.module}/files/kms/audit_key_policy.json", {
+    audit_account_id  = var.control_tower_account_ids.audit
+    master_account_id = data.aws_caller_identity.current.account_id
+  })
 }
 
 module "security_hub_audit" {

--- a/audit.tf
+++ b/audit.tf
@@ -35,7 +35,8 @@ resource "aws_config_aggregate_authorization" "audit" {
 }
 
 resource "aws_config_configuration_aggregator" "audit" {
-  name = "audit"
+  providers = { aws = aws.audit }
+  name      = "audit"
 
   account_aggregation_source {
     account_ids = [

--- a/audit.tf
+++ b/audit.tf
@@ -6,6 +6,19 @@ provider "aws" {
   }
 }
 
+resource "aws_cloudwatch_event_bus" "monitor_iam_access_audit" {
+  provider = aws.audit
+  name     = "LandingZone-MonitorIAMAccess"
+}
+
+resource "aws_cloudwatch_event_permission" "organization_access_audit" {
+  for_each       = { for account in data.aws_organizations_organization.default.accounts : account.id => account.name if account.id != var.control_tower_account_ids.audit }
+  provider       = aws.audit
+  event_bus_name = aws_cloudwatch_event_bus.monitor_iam_access_audit.name
+  principal      = each.key
+  statement_id   = "${each.value}Access"
+}
+
 resource "aws_cloudwatch_event_rule" "monitor_iam_access_audit" {
   for_each    = { for identity, identity_data in local.monitor_iam_access : identity => identity_data if try(identity_data.account, null) == "audit" || identity == "Root" }
   provider    = aws.audit
@@ -24,7 +37,23 @@ resource "aws_cloudwatch_event_target" "monitor_iam_access_audit" {
   provider  = aws.audit
   rule      = each.value.name
   target_id = "SendToSNS"
-  arn       = aws_sns_topic.monitor_iam_access.arn
+  arn       = aws_sns_topic.monitor_iam_access_audit.arn
+}
+
+resource "aws_cloudwatch_event_rule" "notify_iam_access_member_accounts" {
+  provider       = aws.audit
+  name           = "LandingZone-NotifyIAMAccessMemberAccounts"
+  description    = "Monitors IAM access in member accounts"
+  event_bus_name = aws_cloudwatch_event_bus.monitor_iam_access_audit.name
+  event_pattern  = file("${path.module}/files/event_bridge/notify_iam_access.json.tpl")
+}
+
+resource "aws_cloudwatch_event_target" "notify_iam_access_member_accounts" {
+  provider       = aws.audit
+  arn            = aws_sns_topic.monitor_iam_access_audit.arn
+  event_bus_name = aws_cloudwatch_event_bus.monitor_iam_access_audit.name
+  rule           = aws_cloudwatch_event_rule.notify_iam_access_member_accounts.name
+  target_id      = "SendToSNS"
 }
 
 resource "aws_config_aggregate_authorization" "audit" {
@@ -35,8 +64,8 @@ resource "aws_config_aggregate_authorization" "audit" {
 }
 
 resource "aws_config_configuration_aggregator" "audit" {
-  providers = { aws = aws.audit }
-  name      = "audit"
+  provider = aws.audit
+  name     = "audit"
 
   account_aggregation_source {
     account_ids = [
@@ -46,14 +75,16 @@ resource "aws_config_configuration_aggregator" "audit" {
   }
 }
 
-resource "aws_sns_topic" "monitor_iam_access" {
+resource "aws_sns_topic" "monitor_iam_access_audit" {
+  provider          = aws.audit
   name              = "LandingZone-MonitorIAMAccess"
   kms_master_key_id = module.kms_key_audit.id
 }
 
-resource "aws_sns_topic_policy" "monitor_iam_access" {
-  arn    = aws_sns_topic.monitor_iam_access.arn
-  policy = data.aws_iam_policy_document.monitor_iam_access_sns_topic_policy.json
+resource "aws_sns_topic_policy" "monitor_iam_access_audit" {
+  provider = aws.audit
+  arn      = aws_sns_topic.monitor_iam_access_audit.arn
+  policy   = data.aws_iam_policy_document.monitor_iam_access_audit_topic.json
 }
 
 module "datadog_audit" {

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "monitor_iam_access_sns_topic_policy" {
   provider = aws.audit
 

--- a/data.tf
+++ b/data.tf
@@ -1,27 +1,67 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_iam_policy_document" "monitor_iam_access_sns_topic_policy" {
-  provider = aws.audit
+data "aws_iam_policy_document" "monitor_iam_access_audit_topic" {
+  statement {
+    actions = [
+      "SNS:AddPermission",
+      "SNS:DeleteTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Publish",
+      "SNS:Receive",
+      "SNS:RemovePermission",
+      "SNS:SetTopicAttributes",
+      "SNS:Subscribe"
+    ]
+
+    resources = [
+      aws_sns_topic.monitor_iam_access_audit.arn
+    ]
+
+    sid = "__default_statement_ID"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        var.control_tower_account_ids.audit
+      ]
+    }
+  }
 
   statement {
-    effect  = "Allow"
-    actions = ["SNS:Publish"]
+    actions = [
+      "sns:Publish"
+    ]
+
+    resources = [
+      aws_sns_topic.monitor_iam_access_audit.arn
+    ]
+
+    sid = "__events"
 
     principals {
       type        = "Service"
       identifiers = ["events.amazonaws.com"]
     }
+  }
+}
 
-    condition {
-      test     = "StringEquals"
-      variable = "aws:PrincipalOrgID"
+data "aws_iam_policy_document" "monitor_iam_access" {
+  statement {
+    actions = [
+      "events:PutEvents"
+    ]
 
-      values = [
-        data.aws_organizations_organization.default.id
-      ]
-    }
-
-    resources = [aws_sns_topic.monitor_iam_access.arn]
+    resources = [
+      aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
+    ]
   }
 }
 

--- a/files/event_bridge/notify_iam_access.json.tpl
+++ b/files/event_bridge/notify_iam_access.json.tpl
@@ -2,8 +2,5 @@
   "detail-type": [
     "AWS API Call via CloudTrail",
     "AWS Console Sign In via CloudTrail"
-  ],
-  "detail": {
-    "userIdentity": ${userIdentity}
-  }
+  ]
 }

--- a/files/kms/audit_key_policy.json
+++ b/files/kms/audit_key_policy.json
@@ -1,14 +1,31 @@
 {
-  "Sid": "Allow_CloudWatch_for_CMK",
-  "Effect": "Allow",
-  "Principal": {
-    "Service":[
-      "events.amazonaws.com"
-    ]
-  },
-  "Action": [
-    "kms:Decrypt",
-    "kms:GenerateDataKey"
-  ],
-  "Resource": "*"
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+          "AWS": [
+            "arn:aws:iam::${audit_account_id}:root",
+            "arn:aws:iam::${master_account_id}:root"
+          ]
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow_CloudWatch_for_CMK",
+      "Effect": "Allow",
+      "Principal": {
+        "Service":[
+          "events.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "*"
+    }
+  ]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   aws_config_aggregators = flatten([
-    for account in toset(concat(try(var.aws_config.aggregator_account_ids, []), [var.control_tower_account_ids.audit])) : [
-      for region in toset(concat(try(var.aws_config.aggregator_regions, []), ["eu-central-1", "eu-west-1"])) : {
+    for account in toset(try(var.aws_config.aggregator_account_ids, [])) : [
+      for region in toset(try(var.aws_config.aggregator_regions, [])) : {
         account_id = account
         region     = region
       }

--- a/locals.tf
+++ b/locals.tf
@@ -22,7 +22,7 @@ locals {
         "account" = identity.account
         "userIdentity" = {
           "type"     = [identity.type]
-          "userName" = identity.name
+          "userName" = [identity.name]
         }
       } if identity.type == "IAMUser"
     },
@@ -33,7 +33,7 @@ locals {
           "type" = [identity.type]
           "sessionContext" = {
             "sessionIssuer" = {
-              "userName" = identity.name
+              "userName" = [identity.name]
             }
           }
         }

--- a/logging.tf
+++ b/logging.tf
@@ -22,9 +22,12 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access_logging" {
 resource "aws_cloudwatch_event_target" "monitor_iam_access_logging" {
   for_each  = aws_cloudwatch_event_rule.monitor_iam_access_logging
   provider  = aws.logging
+  arn       = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
+  role_arn  = aws_iam_role.monitor_iam_access_logging.arn
   rule      = each.value.name
-  target_id = "SendToSNS"
-  arn       = aws_sns_topic.monitor_iam_access.arn
+  target_id = "SendToAuditEventBus"
+
+  depends_on = [aws_cloudwatch_event_permission.organization_access_audit]
 }
 
 resource "aws_config_aggregate_authorization" "logging" {
@@ -32,6 +35,20 @@ resource "aws_config_aggregate_authorization" "logging" {
   provider   = aws.logging
   account_id = each.value.account_id
   region     = each.value.region
+}
+
+resource "aws_iam_role" "monitor_iam_access_logging" {
+  provider           = aws.logging
+  name               = "LandingZone-MonitorIAMAccess"
+  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", { service = "events.amazonaws.com" })
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy" "monitor_iam_access_logging" {
+  provider = aws.logging
+  name     = "LandingZone-MonitorIAMAccess"
+  role     = aws_iam_role.monitor_iam_access_logging.id
+  policy   = data.aws_iam_policy_document.monitor_iam_access.json
 }
 
 module "datadog_logging" {

--- a/logging.tf
+++ b/logging.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_event_target" "monitor_iam_access_logging" {
 }
 
 resource "aws_config_aggregate_authorization" "logging" {
-  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
+  for_each   = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator if aggregator.account_id != var.control_tower_account_ids.audit }
   provider   = aws.logging
   account_id = each.value.account_id
   region     = each.value.region

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,12 @@ resource "aws_cloudwatch_event_rule" "monitor_iam_access_master" {
 
 resource "aws_cloudwatch_event_target" "monitor_iam_access_master" {
   for_each  = aws_cloudwatch_event_rule.monitor_iam_access_master
+  arn       = aws_cloudwatch_event_bus.monitor_iam_access_audit.arn
+  role_arn  = aws_iam_role.monitor_iam_access_master.arn
   rule      = each.value.name
-  target_id = "SendToSNS"
-  arn       = aws_sns_topic.monitor_iam_access.arn
+  target_id = "SendToAuditEventBus"
+
+  depends_on = [aws_cloudwatch_event_permission.organization_access_audit]
 }
 
 resource "aws_config_aggregate_authorization" "master" {
@@ -65,6 +68,18 @@ resource "aws_iam_role" "config_recorder" {
   assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {
     service = "config.amazonaws.com"
   })
+}
+
+resource "aws_iam_role" "monitor_iam_access_master" {
+  name               = "LandingZone-MonitorIAMAccess"
+  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", { service = "events.amazonaws.com" })
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy" "monitor_iam_access_master" {
+  name   = "LandingZone-MonitorIAMAccess"
+  role   = aws_iam_role.monitor_iam_access_logging.id
+  policy = data.aws_iam_policy_document.monitor_iam_access.json
 }
 
 resource "aws_iam_role_policy_attachment" "config_recorder_read_only" {

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -39,9 +39,9 @@ This should prevent the provider from asking you for a Datadog API Key and allow
 
 ## Monitoring IAM Access
 
-This module offers the capability of monitoring IAM activity of both users and roles. To enable this feature, you have to provide the ARN of the SNS Topic that should be notified in case any activity is detected.
+This module offers the capability of monitoring IAM activity of both users and roles. To enable this feature, you have to provide the ARN of the EventBridge Event Bus that should receive events in case any activity is detected.
 
-The topic ARN can be set using the attribute `sns_topic_arn` in the variable `monitor_iam_access`. In case the feature is enabled, the activity of the `root` user will be automatically monitored and reported.
+The event bus ARN can be set using the attribute `event_bus_arn` in the variable `monitor_iam_access`. In case the feature is enabled, the activity of the `root` user will be automatically monitored and reported.
 
 If you would like to monitor other users or roles, a list can be passed using the attribute `identities` in the variable `monitor_iam_access`. All objects in the list should have the attributes `name` and `type` where `name` is either the name of the IAM Role or the IAM User and `type` is either `AssumedRole` or `IAMUser`. 
 
@@ -53,8 +53,8 @@ Example:
 
 ```hcl
 monitor_iam_access = {
-  sns_topic_arn = aws_sns_topic.monitor_iam_access.arn
-  identities = [
+  event_bus_arn = aws_cloudwatch_event_bus.monitor_iam_access.arn
+  identities    = [
     {
       name = "AWSReservedSSO_AWSAdministratorAccess_123abc"
       type = "AssumedRole"

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -69,7 +69,7 @@ monitor_iam_access = {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | ~> 3.7.0 |
+| aws | ~> 3.16.0 |
 | datadog | ~> 2.14 |
 | github | ~> 3.1.0 |
 | mcaf | ~> 0.1.0 |
@@ -79,7 +79,7 @@ monitor_iam_access = {
 
 | Name | Version |
 |------|---------|
-| aws.managed\_by\_inception | ~> 3.7.0 |
+| aws.managed\_by\_inception | ~> 3.16.0 |
 
 ## Inputs
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -79,6 +79,7 @@ monitor_iam_access = {
 
 | Name | Version |
 |------|---------|
+| aws | ~> 3.16.0 |
 | aws.managed\_by\_inception | ~> 3.16.0 |
 
 ## Inputs
@@ -95,7 +96,7 @@ monitor_iam_access = {
 | email | Email address of the account | `string` | `null` | no |
 | environment | Stack environment | `string` | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |
-| monitor\_iam\_access | Object containing list of IAM Identities that should have their access monitored and the SNS Topic that should be notified | <pre>object({<br>    sns_topic_arn = string<br>    identities = list(object({<br>      name = string<br>      type = string<br>    }))<br>  })</pre> | `null` | no |
+| monitor\_iam\_access | Object containing list of IAM Identities that should have their access monitored and the EventBridge Event Bus that should receive captured events | <pre>object({<br>    event_bus_arn = string<br>    identities = list(object({<br>      name = string<br>      type = string<br>    }))<br>  })</pre> | `null` | no |
 | organizational\_unit | Organizational Unit to place account in | `string` | `null` | no |
 | provisioned\_product\_name | A custom name for the provisioned product | `string` | `null` | no |
 | region | The default region of the account | `string` | `"eu-west-1"` | no |

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -6,6 +6,8 @@ Terraform module to provision an AWS account with a TFE workspace backed by a VC
 
 If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively.
 
+NOTE: Control Tower already authorizes the `audit` account to aggregate Config data from all other accounts in the organization, so there is no need to specify the `audit` account ID in the `aggregator_account_ids` list.
+
 Example:
 
 ```hcl

--- a/modules/avm/files/iam/service_assume_role.json.tpl
+++ b/modules/avm/files/iam/service_assume_role.json.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "${service}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}

--- a/modules/avm/variables.tf
+++ b/modules/avm/variables.tf
@@ -77,14 +77,14 @@ variable "provisioned_product_name" {
 
 variable "monitor_iam_access" {
   type = object({
-    sns_topic_arn = string
+    event_bus_arn = string
     identities = list(object({
       name = string
       type = string
     }))
   })
   default     = null
-  description = "Object containing list of IAM Identities that should have their access monitored and the SNS Topic that should be notified"
+  description = "Object containing list of IAM Identities that should have their access monitored and the EventBridge Event Bus that should receive captured events"
 }
 
 variable "region" {

--- a/modules/avm/versions.tf
+++ b/modules/avm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.7.0"
+      version = "~> 3.16.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "kms_key_id" {
 
 output "monitor_iam_access_sns_topic_arn" {
   description = "ARN of the SNS Topic in the Audit account for IAM access monitoring notifications"
-  value       = aws_sns_topic.monitor_iam_access.arn
+  value       = aws_sns_topic.monitor_iam_access_audit.arn
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.7.0"
+      version = "~> 3.16.0"
     }
     okta = {
       source  = "oktadeveloper/okta"


### PR DESCRIPTION
This PR contains multiple bug fixes that are explained below on a per-commit basis.

### Event pattern error

The previously merged event pattern to monitor IAM access was wrong. The attribute `userName` should be an array and not a string.

### AWS Config Aggregate Authorizations

Control Tower already authorizes the `audit` account to aggregate data from all other accounts in the Organization except for the `master` account. So, by creating new authorization resources, we were overriding the ones created by Control Tower.

To address the fact that the `master` account is not part of the aggregation managed by Control Tower, we add a specific authorization between the `audit` and `master` accounts.

### KMS key policy

The current policy is too strict and doesn't allow the creator of the key to manage it after creation. This prevents Terraform from creating the key.

### Cross-account Event Rule Target

The current approach to send IAM access events to SNS wasn't compatible with EventBridge limitations for cross-account targets. This means that a rule cannot use a topic in another account as a target.

So this change implements a different approach, where we have a dedicated bus in the `audit` account for IAM monitoring and from there we send the events to the SNS topic.

Since this change uses the Terraform resource `aws_cloudwatch_event_bus` which is only available in version `3.14` or higher of the AWS provider, this PR proposes requiring the latest version available at this time: `3.16`.

