### PR TITLE
Prevent recreation of the aws_securityhub_member resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Prevent recreation of the aws_securityhub_member resource ([#25](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/25))
+
 ## 0.2.0 (2020-11-20)
 
 ENHANCEMENTS

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -12,7 +12,6 @@ resource "aws_securityhub_member" "default" {
   for_each   = var.member_accounts
   account_id = each.key
   email      = each.value
-  invite     = true
   depends_on = [aws_securityhub_account.default]
 }
 


### PR DESCRIPTION
Remove the invite line in the aws_securityhub_member resource since this is only needed when inviting member accounts that are not in our organization.