### PR TITLE
Remove MCAF version pin in AVM

### DIFF
--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -72,7 +72,6 @@ monitor_iam_access = {
 | aws | ~> 3.16.0 |
 | datadog | ~> 2.14 |
 | github | ~> 3.1.0 |
-| mcaf | ~> 0.1.0 |
 | tfe | ~> 0.21.0 |
 
 ## Providers

--- a/modules/avm/versions.tf
+++ b/modules/avm/versions.tf
@@ -13,8 +13,7 @@ terraform {
       version = "~> 3.1.0"
     }
     mcaf = {
-      source  = "schubergphilis/mcaf"
-      version = "~> 0.1.0"
+      source = "schubergphilis/mcaf"
     }
     tfe = {
       source  = "hashicorp/tfe"


### PR DESCRIPTION
By removing this we allow people to pin the version in the calling module.