### PR TITLE
Add support for an additional CloudTrail Trail configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Add support for an additional CloudTrail Trail configuration ([#28](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/28))
+
 ## 0.2.1 (2020-11-30)
 
 * Fix recreation of the aws_securityhub_member resource ([#25](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/25))

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ aws_allowed_regions = ["eu-west-1"]
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map` | n/a | yes |
+| additional\_auditing\_trail | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
 | aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # terraform-aws-mcaf-landing-zone
 Terraform module to setup and manage various components of the AWS Landing Zone.
 
+## AWS CloudTrail
+
+By default, all CloudTrail logs will be stored in a S3 bucket in the `logging` account of your AWS Organization. However, this module also supports creating an additional CloudTrail configuration to publish logs to any S3 bucket chosen by you. This trail will be set at the Organization level, meaning that logs from all accounts will be published to the provided bucket.
+
+Example:
+
+```hcl
+additional_auditing_trail = {
+  name   = "additional_auditing_trail"
+  bucket = "bucket_name"
+}
+```
+
 ## AWS Config Rules
 
 This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed via the variable `aws_config` using the attribute `rule_identifiers`.

--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ aws_allowed_regions = ["eu-west-1"]
 | aws\_sso\_acs\_url | AWS SSO ACS URL for the Okta App | `string` | n/a | yes |
 | aws\_sso\_entity\_id | AWS SSO Entity ID for the Okta App | `string` | n/a | yes |
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
-| tags | Map of tags | `map` | n/a | yes |
+| tags | Map of tags | `map(string)` | n/a | yes |
 | additional\_auditing\_trail | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
 | aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
-| aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list` | `[]` | no |
+| aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,10 @@
+resource "aws_cloudtrail" "additional_auditing_trail" {
+  count                 = var.additional_auditing_trail != null ? 1 : 0
+  name                  = var.additional_auditing_trail.name
+  s3_bucket_name        = var.additional_auditing_trail.bucket
+  is_organization_trail = true
+}
+
 resource "aws_cloudwatch_event_rule" "monitor_iam_access_master" {
   for_each    = { for identity, identity_data in local.monitor_iam_access : identity => identity_data if try(identity_data.account, null) == "master" || identity == "Root" }
   name        = substr("LandingZone-MonitorIAMAccess-${each.key}", 0, 64)

--- a/modules/security_hub/README.md
+++ b/modules/security_hub/README.md
@@ -19,8 +19,8 @@ Terraform module to setup and manage AWS Security Hub.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| member\_accounts | A map of accounts that should be added as SecurityHub Member Accounts (format: account\_id = email) | `map` | `{}` | no |
-| product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list` | `[]` | no |
+| member\_accounts | A map of accounts that should be added as SecurityHub Member Accounts (format: account\_id = email) | `map(string)` | `{}` | no |
+| product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |
 | region | The name of the AWS region where SecurityHub will be enabled | `string` | `"eu-west-1"` | no |
 
 ## Outputs

--- a/modules/security_hub/variables.tf
+++ b/modules/security_hub/variables.tf
@@ -1,11 +1,11 @@
 variable "member_accounts" {
-  type        = map
+  type        = map(string)
   default     = {}
   description = "A map of accounts that should be added as SecurityHub Member Accounts (format: account_id = email)"
 }
 
 variable "product_arns" {
-  type        = list
+  type        = list(string)
   default     = []
   description = "A list of the ARNs of the products you want to import into Security Hub"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "additional_auditing_trail" {
+  type = object({
+    name   = string
+    bucket = string
+  })
+  default     = null
+  description = "CloudTrail configuration for additional auditing trail"
+}
+
 variable "aws_allowed_regions" {
   type        = list(string)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "aws_guardduty" {
 }
 
 variable "aws_okta_group_ids" {
-  type        = list
+  type        = list(string)
   default     = []
   description = "List of Okta group IDs that should be assigned the AWS SSO Okta app"
 }
@@ -80,6 +80,6 @@ variable "monitor_iam_access" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(string)
   description = "Map of tags"
 }


### PR DESCRIPTION
We would like to be able to push logs to a bucket managed by our Security Team. 

This change adds the capacity to create an additional CloudTrail Trail to publish logs to a different S3 bucket than the one in the `logging` account of the AWS Organization.