### PR TITLE
Add support for exemptions to the AWS region restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Add support for exemptions to the AWS region restriction ([#31](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/31))
+
 ## 0.4.0 (2020-12-16)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -110,12 +110,17 @@ This is SCP is enabled by default, but can be disabled by setting `aws_require_i
 
 ### Restricting AWS Regions
 
-If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_allowed_regions`. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.
+If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_region_restrictions` using the `allowed` attribute. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.
+
+In case you would like to exempt specific IAM entities from the region restriction, you can pass a list of ARN patterns using the `exceptions` attribute. This can be useful for roles used by AWS ControlTower, for example, to avoid preventing it from managing all regions properly.
 
 Example:
 
 ```hcl
-aws_allowed_regions = ["eu-west-1"]
+aws_region_restrictions = {
+  allowed    = ["eu-west-1"]
+  exceptions = ["arn:aws:iam::*:role/RoleAllowedToBypassRegionRestrictions"]
+}
 ```
 
 ### Restricting Root User Access

--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ module "landing_zone" {
 | control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
 | tags | Map of tags | `map(string)` | n/a | yes |
 | additional\_auditing\_trail | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
-| aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_deny\_leaving\_org | Enable SCP that denies accounts the ability to leave the AWS organisation | `bool` | `true` | no |
 | aws\_deny\_root\_user\_ous | List of AWS Organisation OUs to apply the "DenyRootUser" SCP to | `list(string)` | `[]` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
+| aws\_region\_restrictions | List of allowed AWS regions and principals that are exempt from the restriction | <pre>object({<br>    allowed    = list(string)<br>    exceptions = list(string)<br>  })</pre> | `null` | no |
 | aws\_require\_imdsv2 | Enable SCP that requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |

--- a/files/organizations/allowed_regions_scp.json.tpl
+++ b/files/organizations/allowed_regions_scp.json.tpl
@@ -48,8 +48,13 @@
             "Resource": "*",
             "Condition": {
                 "StringNotEquals": {
-                    "aws:RequestedRegion": ${allowed_regions}
+                    "aws:RequestedRegion": ${jsonencode(allowed)}
                 }
+                %{ if length(exceptions) > 0 ~}
+                ,"ArnNotLike": {
+                    "aws:PrincipalARN": ${jsonencode(exceptions)}
+                }
+                %{ endif ~}
             }
         }
     ]

--- a/scps.tf
+++ b/scps.tf
@@ -1,14 +1,15 @@
 resource "aws_organizations_policy" "allowed_regions" {
-  count = var.aws_allowed_regions != null ? 1 : 0
+  count = var.aws_region_restrictions != null ? 1 : 0
   name  = "LandingZone-AllowedRegions"
 
   content = templatefile("${path.module}/files/organizations/allowed_regions_scp.json.tpl", {
-    allowed_regions = jsonencode(var.aws_allowed_regions)
+    allowed    = var.aws_region_restrictions.allowed
+    exceptions = var.aws_region_restrictions.exceptions
   })
 }
 
 resource "aws_organizations_policy_attachment" "allowed_regions" {
-  count     = var.aws_allowed_regions != null ? 1 : 0
+  count     = var.aws_region_restrictions != null ? 1 : 0
   policy_id = aws_organizations_policy.allowed_regions.0.id
   target_id = data.aws_organizations_organization.default.roots.0.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,6 @@ variable "additional_auditing_trail" {
   description = "CloudTrail configuration for additional auditing trail"
 }
 
-variable "aws_allowed_regions" {
-  type        = list(string)
-  default     = null
-  description = "List of allowed AWS regions"
-}
-
 variable "aws_config" {
   type = object({
     aggregator_account_ids = list(string)
@@ -44,6 +38,15 @@ variable "aws_okta_group_ids" {
   type        = list(string)
   default     = []
   description = "List of Okta group IDs that should be assigned the AWS SSO Okta app"
+}
+
+variable "aws_region_restrictions" {
+  type = object({
+    allowed    = list(string)
+    exceptions = list(string)
+  })
+  default     = null
+  description = "List of allowed AWS regions and principals that are exempt from the restriction"
 }
 
 variable "aws_require_imdsv2" {


### PR DESCRIPTION
The current region restriction prevents ControlTower from properly managing accounts in all regions.

This change introduces the support for exempting IAM entities from the region restriction so that, for example, the roles used by ControlTower can still do everything they have to do in all regions.