### PR TITLE
Add DenyRootUser SCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Add a `DenyRootUser` SCP that can be attached to AWS Organisation OUs
+
 ## 0.3.2 (2020-12-14)
 
 * Fix support for Datadog region ([#34]https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/34)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ monitor_iam_access = [
 ]
 ```
 
-## Restricting AWS Regions
+## Service Control Policies (SCPs)
+
+Service control policies (SCPs) are a type of organization policy that you can use to manage permissions in your organization. See [this page](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) for an introduction to SCPs and the value they add.
+
+This module allows using various SCPs as described below. We try to adhere to best practices of not attaching SCPs to the root of the organisation when possible; in the event you need to pass a list of OU names, be sure to have the exact name as the matching is case sensitive.
+
+### Restricting AWS Regions
 
 If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_allowed_regions`. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.
 
@@ -98,6 +104,27 @@ Example:
 
 ```hcl
 aws_allowed_regions = ["eu-west-1"]
+```
+
+### Restricting Root User Access
+
+If you would like to restrict the root user's ability to log into accounts in an OU, you can pass a list of OU names to the `aws_deny_root_user_ous` variable.
+
+Example showing SCP applied to all OUs except the Root OU:
+
+```hcl
+data "aws_organizations_organization" "default" {}
+
+data "aws_organizations_organizational_units" "default" {
+  parent_id = data.aws_organizations_organization.default.roots[0].id
+}
+
+module "landing_zone" {
+  ...
+
+  aws_deny_root_user_ous = [
+    for ou in data.aws_organizations_organizational_units.default.children : ou.name if ou.name != "Root"
+  ]
 ```
 
 <!--- BEGIN_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ module "landing_zone" {
 | additional\_auditing\_trail | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
 | aws\_allowed\_regions | List of allowed AWS regions | `list(string)` | `null` | no |
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
+| aws\_deny\_root\_user\_ous | List of AWS Organisation OUs to apply the "DenyRootUser" SCP to | `list(string)` | `[]` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |

--- a/data.tf
+++ b/data.tf
@@ -101,6 +101,10 @@ data "aws_iam_user" "monitor_iam_access_master" {
 
 data "aws_organizations_organization" "default" {}
 
+data "aws_organizations_organizational_units" "default" {
+  parent_id = data.aws_organizations_organization.default.roots[0].id
+}
+
 data "aws_region" "current" {}
 
 data "aws_sns_topic" "all_config_notifications" {

--- a/files/organizations/deny_root_user.json
+++ b/files/organizations/deny_root_user.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyRootUser",
+      "Effect": "Deny",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:PrincipalArn": "arn:aws:iam::*:root"
+        }
+      }
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,21 @@ resource "aws_organizations_policy_attachment" "allowed_regions" {
   target_id = data.aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy" "deny_root_user" {
+  count   = length(var.aws_deny_root_user_ous) > 0 ? 1 : 0
+  name    = "LandingZone-DenyRootUser"
+  content = file("${path.module}/files/organizations/deny_root_user.json")
+}
+
+resource "aws_organizations_policy_attachment" "deny_root_user" {
+  for_each = {
+    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(var.aws_deny_root_user_ous, ou.name)
+  }
+
+  policy_id = aws_organizations_policy.deny_root_user.0.id
+  target_id = each.value.id
+}
+
 module "datadog_master" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.3"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "aws_config" {
   description = "AWS Config settings"
 }
 
+variable "aws_deny_root_user_ous" {
+  type        = list(string)
+  default     = []
+  description = "List of AWS Organisation OUs to apply the \"DenyRootUser\" SCP to"
+}
+
 variable "aws_guardduty" {
   type        = bool
   default     = true


### PR DESCRIPTION
Example documented in the README; this PR adds the ability to deny the root user access to resources by attaching an SCP to an OU as per [the documented example](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html).