### PR TITLE
Add SCP that requires use of IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## Unreleased
 
 * Add a `DenyRootUser` SCP that can be attached to AWS Organisation OUs
+* Add a `RequireUseOfIMDSv2` SCP that is attached to all AWS Organisation OUs by default
 
 ## 0.3.2 (2020-12-14)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Service control policies (SCPs) are a type of organization policy that you can u
 
 This module allows using various SCPs as described below. We try to adhere to best practices of not attaching SCPs to the root of the organisation when possible; in the event you need to pass a list of OU names, be sure to have the exact name as the matching is case sensitive.
 
+### Require the use of Instance Metadata Service Version 2
+
+By default, all EC2s still allow access to the original metadata service, which means that if an attacker finds an EC2 running a proxy or WAF, or finds and SSRF vulnerability, they likely can steal the IAM role of the EC2. By enforcing IMDSv2, you can mitigate that risk. Be aware that this potentially could break some applications that have not yet been updated to work with the new IMDSv2.
+
+This is SCP is enabled by default, but can be disabled by setting `aws_require_imdsv2` variable to `false`.
+
 ### Restricting AWS Regions
 
 If you would like to define which AWS Regions can be used in your AWS Organization, you can pass a list of region names to the variable `aws_allowed_regions`. This will trigger this module to deploy a [Service Control Policy (SCP) designed by AWS](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html#example-scp-deny-region) and attach it to the root of your AWS Organization.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ module "landing_zone" {
 | aws\_deny\_root\_user\_ous | List of AWS Organisation OUs to apply the "DenyRootUser" SCP to | `list(string)` | `[]` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
+| aws\_require\_imdsv2 | Enable SCP that requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
 

--- a/files/organizations/require_use_of_imdsv2.json
+++ b/files/organizations/require_use_of_imdsv2.json
@@ -1,0 +1,43 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RequireAllEc2RolesToUseV2",
+      "Effect": "Deny",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "NumericLessThan": {
+          "ec2:RoleDelivery": "2.0"
+        }
+      }
+    },
+    {
+      "Sid": "RequireImdsV2",
+      "Effect": "Deny",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "StringNotEquals": {
+          "ec2:MetadataHttpTokens": "required"
+        }
+      }
+    },
+    {
+      "Effect": "Deny",
+      "Action": "ec2:ModifyInstanceMetadataOptions",
+      "Resource": "*"
+    },
+    {
+      "Sid": "MaxImdsHopLimit",
+      "Effect": "Deny",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "NumericGreaterThan": {
+          "ec2:MetadataHttpPutResponseHopLimit": "3"
+        }
+      }
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -110,36 +110,6 @@ resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
 }
 
-resource "aws_organizations_policy" "allowed_regions" {
-  count = var.aws_allowed_regions != null ? 1 : 0
-  name  = "LandingZone-AllowedRegions"
-
-  content = templatefile("${path.module}/files/organizations/allowed_regions_scp.json.tpl", {
-    allowed_regions = jsonencode(var.aws_allowed_regions)
-  })
-}
-
-resource "aws_organizations_policy_attachment" "allowed_regions" {
-  count     = var.aws_allowed_regions != null ? 1 : 0
-  policy_id = aws_organizations_policy.allowed_regions[0].id
-  target_id = data.aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy" "deny_root_user" {
-  count   = length(var.aws_deny_root_user_ous) > 0 ? 1 : 0
-  name    = "LandingZone-DenyRootUser"
-  content = file("${path.module}/files/organizations/deny_root_user.json")
-}
-
-resource "aws_organizations_policy_attachment" "deny_root_user" {
-  for_each = {
-    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(var.aws_deny_root_user_ous, ou.name)
-  }
-
-  policy_id = aws_organizations_policy.deny_root_user.0.id
-  target_id = each.value.id
-}
-
 module "datadog_master" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
   source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.3"

--- a/scps.tf
+++ b/scps.tf
@@ -9,8 +9,8 @@ resource "aws_organizations_policy" "allowed_regions" {
 
 resource "aws_organizations_policy_attachment" "allowed_regions" {
   count     = var.aws_allowed_regions != null ? 1 : 0
-  policy_id = aws_organizations_policy.allowed_regions[0].id
-  target_id = data.aws_organizations_organization.default.roots[0].id
+  policy_id = aws_organizations_policy.allowed_regions.0.id
+  target_id = data.aws_organizations_organization.default.roots.0.id
 }
 
 resource "aws_organizations_policy" "deny_root_user" {
@@ -26,4 +26,17 @@ resource "aws_organizations_policy_attachment" "deny_root_user" {
 
   policy_id = aws_organizations_policy.deny_root_user.0.id
   target_id = each.value.id
+}
+
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ExamplePolicies_EC2.html#iam-example-instance-metadata-requireIMDSv2
+resource "aws_organizations_policy" "require_use_of_imdsv2" {
+  count   = var.aws_require_imdsv2 == true ? 1 : 0
+  name    = "LandingZone-RequireUseOfIMDSv2"
+  content = file("${path.module}/files/organizations/require_use_of_imdsv2.json")
+}
+
+resource "aws_organizations_policy_attachment" "require_use_of_imdsv2" {
+  count     = var.aws_require_imdsv2 == true ? 1 : 0
+  policy_id = aws_organizations_policy.require_use_of_imdsv2.0.id
+  target_id = data.aws_organizations_organization.default.roots.0.id
 }

--- a/scps.tf
+++ b/scps.tf
@@ -1,0 +1,29 @@
+resource "aws_organizations_policy" "allowed_regions" {
+  count = var.aws_allowed_regions != null ? 1 : 0
+  name  = "LandingZone-AllowedRegions"
+
+  content = templatefile("${path.module}/files/organizations/allowed_regions_scp.json.tpl", {
+    allowed_regions = jsonencode(var.aws_allowed_regions)
+  })
+}
+
+resource "aws_organizations_policy_attachment" "allowed_regions" {
+  count     = var.aws_allowed_regions != null ? 1 : 0
+  policy_id = aws_organizations_policy.allowed_regions[0].id
+  target_id = data.aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy" "deny_root_user" {
+  count   = length(var.aws_deny_root_user_ous) > 0 ? 1 : 0
+  name    = "LandingZone-DenyRootUser"
+  content = file("${path.module}/files/organizations/deny_root_user.json")
+}
+
+resource "aws_organizations_policy_attachment" "deny_root_user" {
+  for_each = {
+    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(var.aws_deny_root_user_ous, ou.name)
+  }
+
+  policy_id = aws_organizations_policy.deny_root_user.0.id
+  target_id = each.value.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "aws_okta_group_ids" {
   description = "List of Okta group IDs that should be assigned the AWS SSO Okta app"
 }
 
+variable "aws_require_imdsv2" {
+  type        = bool
+  default     = true
+  description = "Enable SCP that requires EC2 instances to use V2 of the Instance Metadata Service"
+}
+
 variable "aws_sso_acs_url" {
   type        = string
   description = "AWS SSO ACS URL for the Okta App"


### PR DESCRIPTION
This was a Security Hub finding in a customer environment, see [this link](https://summitroute.com/blog/2020/03/25/aws_scp_best_practices/#require-the-use-of-imdsv2) for info on what the policy does in more detail.