### PR TITLE
Allow newer github provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ module "landing_zone" {
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
 | aws\_region\_restrictions | List of allowed AWS regions and principals that are exempt from the restriction | <pre>object({<br>    allowed    = list(string)<br>    exceptions = list(string)<br>  })</pre> | `null` | no |
-| aws\_require\_imdsv2 | Enable SCP that requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
+| aws\_require\_imdsv2 | Enable SCP which requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -72,7 +72,7 @@ monitor_iam_access = {
 | terraform | >= 0.13 |
 | aws | ~> 3.16.0 |
 | datadog | ~> 2.14 |
-| github | ~> 3.1.0 |
+| github | >= 3.1.0 |
 | tfe | ~> 0.21.0 |
 
 ## Providers

--- a/modules/avm/versions.tf
+++ b/modules/avm/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     github = {
       source  = "hashicorp/github"
-      version = "~> 3.1.0"
+      version = ">= 3.1.0"
     }
     mcaf = {
       source = "schubergphilis/mcaf"


### PR DESCRIPTION
This constraint matches what is used in the repository MCAF module and allows more flexibility for the consumer of the module. We should see any negative impact as the consumer can use a more restrictive constraint in their calling module.