### PR TITLE
Loosen provider version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,17 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | ~> 3.16.0 |
-| okta | ~> 3.0 |
+| aws | >= 3.16.0 |
+| okta | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.16.0 |
-| aws.audit | ~> 3.16.0 |
-| aws.logging | ~> 3.16.0 |
-| okta | ~> 3.0 |
+| aws | >= 3.16.0 |
+| aws.audit | >= 3.16.0 |
+| aws.logging | >= 3.16.0 |
+| okta | >= 3.0 |
 
 ## Inputs
 
@@ -177,7 +177,7 @@ module "landing_zone" {
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
 | aws\_okta\_group\_ids | List of Okta group IDs that should be assigned the AWS SSO Okta app | `list(string)` | `[]` | no |
 | aws\_region\_restrictions | List of allowed AWS regions and principals that are exempt from the restriction | <pre>object({<br>    allowed    = list(string)<br>    exceptions = list(string)<br>  })</pre> | `null` | no |
-| aws\_require\_imdsv2 | Enable SCP that requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
+| aws\_require\_imdsv2 | Enable SCP which requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
 

--- a/modules/avm/README.md
+++ b/modules/avm/README.md
@@ -70,17 +70,17 @@ monitor_iam_access = {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | ~> 3.16.0 |
-| datadog | ~> 2.14 |
-| github | ~> 3.1.0 |
-| tfe | ~> 0.21.0 |
+| aws | >= 3.16.0 |
+| datadog | >= 2.14 |
+| github | >= 3.1.0 |
+| tfe | >= 0.21.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.16.0 |
-| aws.managed\_by\_inception | ~> 3.16.0 |
+| aws | >= 3.16.0 |
+| aws.managed\_by\_inception | >= 3.16.0 |
 
 ## Inputs
 

--- a/modules/avm/versions.tf
+++ b/modules/avm/versions.tf
@@ -2,22 +2,22 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.16.0"
+      version = ">= 3.16.0"
     }
     datadog = {
       source  = "datadog/datadog"
-      version = "~> 2.14"
+      version = ">= 2.14"
     }
     github = {
       source  = "hashicorp/github"
-      version = "~> 3.1.0"
+      version = ">= 3.1.0"
     }
     mcaf = {
       source = "schubergphilis/mcaf"
     }
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.21.0"
+      version = ">= 0.21.0"
     }
   }
   required_version = ">= 0.13"

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.16.0"
+      version = ">= 3.16.0"
     }
     okta = {
       source  = "oktadeveloper/okta"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This follows best practices as outlined in https://www.terraform.io/docs/configuration/version-constraints.html were a reusable module is less constrained and the calling/root module is more constrained in it's version requirements. This will allow more flexibility for module users on which versions they want to use.