### PR TITLE
Fix bug in the aws_sns_topic_subscription.datadog_security resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 BUG FIXES
 
-* Resolves issue where leaving the sns\_security\_subscription variable empty would cause failure and restructured the variable from a list to a map because in TF v0.14 for\_each statements cannot be used with an object that has sensitive values ([#60](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/60))
+* Resolve issue where an empty `sns_security_subscription` variable causes a failure and restructured the variable to a map as `for_each` in Terraform 0.14 cannot be used with an object that has sensitive values ([#60](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/60))
 
 ## 0.4.3 (2021-01-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+BUG FIXES
+
+* Fix bug in the aws\_sns\_topic\_subscription.datadog\_security resource ([#60](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/60))
+
 ## 0.4.3 (2021-01-04)
 
 ENHANCEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 BUG FIXES
 
-* Fix bug in the aws\_sns\_topic\_subscription.datadog\_security resource ([#60](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/60))
+* Resolves issue where leaving the sns\_security\_subscription variable empty would cause failure and restructured the variable from a list to a map because in TF v0.14 for\_each statements cannot be used with an object that has sensitive values ([#60](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/60))
 
 ## 0.4.3 (2021-01-04)
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ module "landing_zone" {
 | aws\_require\_imdsv2 | Enable SCP which requires EC2 instances to use V2 of the Instance Metadata Service | `bool` | `true` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
 | monitor\_iam\_access | List of IAM Identities that should have their access monitored | <pre>list(object({<br>    account = string<br>    name    = string<br>    type    = string<br>  }))</pre> | `null` | no |
-| sns\_security\_subscription | Aggregated security SNS topic subscription options | <pre>list(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `null` | no |
+| sns\_aws\_config\_subscription | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/modules/security_hub/README.md
+++ b/modules/security_hub/README.md
@@ -22,7 +22,6 @@ Terraform module to setup and manage AWS Security Hub.
 | member\_accounts | A map of accounts that should be added as SecurityHub Member Accounts (format: account\_id = email) | `map(string)` | `{}` | no |
 | product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |
 | region | The name of the AWS region where SecurityHub will be enabled | `string` | `"eu-west-1"` | no |
-| sns\_subscription | Aggregated security SNS topic subscription options | <pre>list(object({<br>    account_id = string<br>    endpoint   = string<br>    protocol   = string<br>  }))</pre> | `null` | no |
 
 ## Outputs
 

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -26,11 +26,3 @@ resource "aws_securityhub_standards_subscription" "default" {
   standards_arn = each.value
   depends_on    = [aws_securityhub_account.default]
 }
-
-resource "aws_sns_topic_subscription" "datadog_security" {
-  for_each   = toset(try(var.sns_subscription, []))
-  endpoint   = each.value.endpoint
-  protocol   = each.value.protocol
-  topic_arn  = "arn:aws:sns:${var.region}:${each.value.account_id}:aws-controltower-AggregateSecurityNotifications"
-  depends_on = [aws_securityhub_account.default]
-}

--- a/modules/security_hub/variables.tf
+++ b/modules/security_hub/variables.tf
@@ -15,13 +15,3 @@ variable "region" {
   default     = "eu-west-1"
   description = "The name of the AWS region where SecurityHub will be enabled"
 }
-
-variable "sns_subscription" {
-  type = list(object({
-    account_id = string
-    endpoint   = string
-    protocol   = string
-  }))
-  default     = null
-  description = "Aggregated security SNS topic subscription options"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -131,13 +131,13 @@ variable "monitor_iam_access" {
   }
 }
 
-variable "sns_security_subscription" {
-  type = list(object({
+variable "sns_aws_config_subscription" {
+  type = map(object({
     endpoint = string
     protocol = string
   }))
-  default     = null
-  description = "Aggregated security SNS topic subscription options"
+  default     = {}
+  description = "Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic"
 }
 
 variable "tags" {


### PR DESCRIPTION
- Resolves issue where leaving the sns_security_subscription variable empty would cause failure.
- Renamed and restructured the sns_security_subscription variable into sns_aws_config_subscription. Changed into a map to prevent the endpoint being used in the for_each. The endpoint can contain a secret (e.g. the datadog api key) and this would cause failure. In TF V0.14 you can't use for_each with an object that has sensitive values. 
- Moved this resource out of the security_hub module since the SNS topic aws-controltower-AggregateSecurityNotifications only contains AWS Config data: https://docs.aws.amazon.com/controltower/latest/userguide/compliance.html