### PR TITLE
Prevent error when aws_required_tags is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+BUG FIXES
+
+* Prevent error when aws_required_tags is not set ([#93](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/93/files))
+
+
 ## 0.7.3 (2021-02-06)
 
 ENHANCEMENTS

--- a/organizations_policy.tf
+++ b/organizations_policy.tf
@@ -58,7 +58,7 @@ resource "aws_organizations_policy_attachment" "deny_leaving_org" {
 // https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_supported-resources-enforcement.html
 resource "aws_organizations_policy" "required_tags" {
   for_each = {
-    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(keys(var.aws_required_tags), ou.name)
+    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(keys(coalesce(var.aws_required_tags, {})), ou.name)
   }
 
   name = "LandingZone-RequiredTags-${each.key}"
@@ -72,7 +72,7 @@ resource "aws_organizations_policy" "required_tags" {
 
 resource "aws_organizations_policy_attachment" "required_tags" {
   for_each = {
-    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(keys(var.aws_required_tags), ou.name)
+    for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(keys(coalesce(var.aws_required_tags, {})), ou.name)
   }
 
   policy_id = aws_organizations_policy.required_tags[each.key].id


### PR DESCRIPTION
When `aws_required_tags` is not set, Terraform throws the following error:

```hcl
Error: Invalid function argument

  on .terraform/modules/landing_zone/organizations_policy.tf line 61, in resource "aws_organizations_policy" "required_tags":
  61:     for ou in data.aws_organizations_organizational_units.default.children : ou.name => ou if contains(keys(try(var.aws_required_tags, {})), ou.name)
    |----------------
    | var.aws_required_tags is null

Invalid value for "inputMap" parameter: argument must not be null.
```

This change adds a way to prevent this error from happening.