### PR TITLE
Add SCP to protect CloudTrail LogStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+ENHANCEMENTS
+
+* Add SCP to protect CloudTrail LogStream ([#94](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/94))
+
 BUG FIXES
 
 * Prevent error when aws_required_tags is not set ([#93](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/93))

--- a/files/organizations/cloudtrail_log_stream.json
+++ b/files/organizations/cloudtrail_log_stream.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Sid": "DenyDeletingCloudTrailLogStream",
+    "Effect": "Deny",
+    "Action": [
+      "logs:DeleteLogStream"
+    ],
+    "Resource": [
+      "arn:aws:logs:*:*:log-group:aws-controltower/CloudTrailLogs:*"
+    ]
+  }
+}

--- a/organizations_policy.tf
+++ b/organizations_policy.tf
@@ -15,6 +15,17 @@ resource "aws_organizations_policy_attachment" "allowed_regions" {
   target_id = data.aws_organizations_organization.default.roots.0.id
 }
 
+resource "aws_organizations_policy" "deny_cloudtrail_log_stream" {
+  name    = "LandingZone-DenyDeletingCloudTrailLogStream"
+  content = file("${path.module}/files/organizations/cloudtrail_log_stream.json")
+  tags    = var.tags
+}
+
+resource "aws_organizations_policy_attachment" "deny_cloudtrail_log_stream" {
+  policy_id = aws_organizations_policy.deny_cloudtrail_log_stream.id
+  target_id = data.aws_organizations_organization.default.roots.0.id
+}
+
 resource "aws_organizations_policy" "deny_root_user" {
   count   = length(var.aws_deny_root_user_ous) > 0 ? 1 : 0
   name    = "LandingZone-DenyRootUser"


### PR DESCRIPTION
Since we are using CloudTrail's CloudWatch Log Group to monitor IAM activity in the accounts, it's important that we protect the log group so that no one can make changes to it.

ControlTower already adds the following statement to one of its SCPs:

```
        {
            "Condition": {
                "StringNotLike": {
                    "aws:PrincipalArn": [
                        "arn:aws:iam::*:role/AWSControlTowerExecution"
                    ]
                }
            },
            "Action": [
                "logs:DeleteLogGroup",
                "logs:PutRetentionPolicy"
            ],
            "Resource": [
                "arn:aws:logs:*:*:log-group:*aws-controltower*"
            ],
            "Effect": "Deny",
            "Sid": "GRLOGGROUPPOLICY"
        },
```

However, this statement doesn't protect the log stream, only the log group.

This change adds an extra SCP to protect the log stream as well.