### PR TITLE
Make list of SecurityHub Standards configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.10.1 (2021-06-30)
+
+ENHANCEMENTS
+
+- Make list of SecurityHub Standards configurable ([#108](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/108))
+
 ## 0.10.0 (2021-05-27)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ module "landing_zone" {
 | kms\_key\_policy | A valid KMS key policy JSON document | `string` | `""` | no |
 | monitor\_iam\_activity | Whether IAM activity should be monitored | `bool` | `true` | no |
 | monitor\_iam\_activity\_sns\_subscription | Subscription options for the LandingZone-IAMActivity SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
+| security\_hub\_standards\_arns | A list of the ARNs of the standards you want to enable in Security Hub | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -34,7 +34,7 @@ locals {
     Root = "{ $.userIdentity.type = \"Root\" }"
     SSO  = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
   }
-  security_hub_standards_arns = [
+  security_hub_standards_arns = var.security_hub_standards_arns != null ? var.security_hub_standards_arns : [
     "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0",
     "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0",
     "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,12 @@ variable "aws_security_hub_sns_subscription" {
   description = "Subscription options for the LandingZone-SecurityHubFindings SNS topic"
 }
 
+variable "security_hub_standards_arns" {
+  type        = list(string)
+  default     = null
+  description = "A list of the ARNs of the standards you want to enable in Security Hub"
+}
+
 variable "aws_sso_permission_sets" {
   type = map(object({
     assignments      = list(map(list(string)))


### PR DESCRIPTION
For our environment, we don't need PCI-DSS compliance, so this change makes the standards configurable.