### PR TITLE
Update IAM activity filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.10.5 (2021-09-07)
+
+- Update IAM Activity Monitor for root usage to match CIS AWS rule 1.1 ([#117](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/117))
+
 ## 0.10.4 (2021-08-23)
 
 - Add a `DenyDisablingSecurityHub` SCP that is attached to all AWS Organisation OUs ([#110](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/110))

--- a/README.md
+++ b/README.md
@@ -277,15 +277,15 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | >= 3.57.0 |
+| aws | >= 3.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.57.0 |
-| aws.audit | >= 3.57.0 |
-| aws.logging | >= 3.57.0 |
+| aws | >= 3.50.0 |
+| aws.audit | >= 3.50.0 |
+| aws.logging | >= 3.50.0 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -277,15 +277,15 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | >= 3.24.0 |
+| aws | >= 3.57.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.24.0 |
-| aws.audit | >= 3.24.0 |
-| aws.logging | >= 3.24.0 |
+| aws | >= 3.57.0 |
+| aws.audit | >= 3.57.0 |
+| aws.logging | >= 3.57.0 |
 
 ## Inputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -31,8 +31,8 @@ locals {
     ]
   ])
   iam_activity = {
-    Root = "{ $.userIdentity.type = \"Root\" }"
-    SSO  = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
+    Root = "{$.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\"}"
+    SSO  = "{$.readOnly IS FALSE && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\"}"
   }
   security_hub_standards_arns = var.security_hub_standards_arns != null ? var.security_hub_standards_arns : [
     "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0",

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.57.0"
+      version = ">= 3.50.0"
     }
   }
   required_version = ">= 0.13"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.24.0"
+      version = ">= 3.57.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Updates the IAM activity filters to use the recommended filter for tracking root activity. The recommended filter is the AWS offered way of remediating CIS 1.1: avoiding the use of the root account. I consciously kept the formatting of the check equal to the rule defined in the remediation instruction to make sure it's auto-detected as solved.

The TF version change is related to https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/commit/8efafd8a0d1ddb106ae762e8ad22b4e6d92f351b.