### PR TITLE
Add support for sso managed policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.13.0 (2021-11-17)
+
+- Add support for assigning managed policies in SSO permission sets ([#124](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/124))
+
 ## 0.12.2 (2021-11-10)
 
 BUG FIXES

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # terraform-aws-mcaf-landing-zone
 Terraform module to setup and manage various components of the SBP AWS Landing Zone.
 
-Overview of Landing Zone tools & services: 
+Overview of Landing Zone tools & services:
 
-<img src="images/MCAF_landing_zone_tools_and_services_v040.png" width="600"> 
+<img src="images/MCAF_landing_zone_tools_and_services_v040.png" width="600">
 
 The SBP AWS Landing Zone consists of 3 repositories:
 - [MCAF Landing Zone module (current repository)](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone): the foundation of the Landing Zone and manages the 3 core accounts: audit, logging, master
@@ -44,7 +44,7 @@ additional_auditing_trail = {
 
 This module provisions by default a set of basic AWS Config Rules. In order to add extra rules, a list of [rule identifiers](https://docs.aws.amazon.com/config/latest/developerguide/managed-rules-by-aws-config.html) can be passed via the variable `aws_config` using the attribute `rule_identifiers`.
 
-If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively. 
+If you would like to authorize other accounts to aggregate AWS Config data, the account IDs and regions can also be passed via the variable `aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively.
 
 NOTE: This module already authorizes the `audit` account to aggregate Config data from all other accounts in the organization, so there is no need to specify the `audit` account ID in the `aggregator_account_ids` list.
 
@@ -74,6 +74,7 @@ This feature can be controlled via the `aws_sso_permission_sets` variable by pas
 
 - `assignments`: list of maps (key-value pair) of AWS Account IDs as keys and a list of AWS SSO Group names that should have access to the account using the permission set defined
 - `inline_policy`: valid IAM policy in JSON format (maximum length of 10240 characters)
+- `managed_policy_arns`: list of strings that contain the ARN's of the managed policies that should be attached to the permission set
 - `session_duration`: length of time in the ISO-8601 standard
 
 Example:
@@ -81,8 +82,12 @@ Example:
 ```hcl
   aws_sso_permission_sets = {
     PlatformAdmin = {
-      inline_policy = file("${path.module}/template_files/sso/platform_admin.json")
+      inline_policy    = file("${path.module}/template_files/sso/platform_admin.json")
       session_duration = "PT2H"
+
+      managed_policy_arns = [
+        "arn:aws:iam::aws:policy/ReadOnlyAccess"
+      ]
 
       assignments = [
         {
@@ -99,6 +104,11 @@ Example:
     }
     PlatformUser = {
       session_duration = "PT12H"
+
+      managed_policy_arns = [
+        "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        "arn:aws:iam::aws:policy/AWSSupportAccess"
+      ]
 
       assignments = [
         {
@@ -225,7 +235,7 @@ module "landing_zone" {
 
 Tag policies are a type of policy that can help you standardize tags across resources in your organization's accounts. In a tag policy, you specify tagging rules applicable to resources when they are tagged. See [this page](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html) for an introduction to tag policies and the value they add.
 
-If you would like to enforce certain tags in an OU, you can pass a map of OU names containing the tags to the `aws_required_tags` variable. Be sure to pass the exact OU name as the matching is case sensitive. If the OU provided does not match any existing OU the tag policy is not created. 
+If you would like to enforce certain tags in an OU, you can pass a map of OU names containing the tags to the `aws_required_tags` variable. Be sure to pass the exact OU name as the matching is case sensitive. If the OU provided does not match any existing OU the tag policy is not created.
 
 Example:
 
@@ -263,7 +273,7 @@ Example for https protocol and specified webhook endpoint:
 ```hcl
 module "landing_zone" {
   ...
-  
+
   aws_config_sns_subscription = {
     endpoint = "https://app.datadoghq.com/intake/webhook/sns?api_key=qwerty0123456789"
     protocol = "https"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,7 @@
+# Upgrading to 0.13.x
+
+Version `0.13.x` adds support for managed policies. This required changing the variable `aws_sso_permission_sets` where each permission set now requires an additional field called `managed_policy_arns` which must be a list of strings or can be an empty list.
+
 # Upgrading to 0.12.x
 
 Version `0.12.x` automatically sets the audit account as security hub administrator account for the organization and automatically enables Security Hub for new accounts in the organization. In case you already configured this manually please import these resources:
@@ -9,7 +13,7 @@ terraform import aws_securityhub_organization_configuration.default <account id 
 
 # Upgrading to 0.11.x
 
-Version `0.11.x` adds additional IAM activity monitors, these will be created automatically if you have the cis-aws-foundations-benchmark standard enabled. To disable the creation of these monitors set the variable `security_hub_create_cis_metric_filters` to false. 
+Version `0.11.x` adds additional IAM activity monitors, these will be created automatically if you have the cis-aws-foundations-benchmark standard enabled. To disable the creation of these monitors set the variable `security_hub_create_cis_metric_filters` to false.
 
 # Upgrading to 0.10.x
 

--- a/locals.tf
+++ b/locals.tf
@@ -30,6 +30,14 @@ locals {
       ]
     ]
   ])
+  aws_sso_managed_policy_arn_assignment = flatten([
+    for permission_set_name, permission_set in var.aws_sso_permission_sets : [
+      for managed_policy_arn in permission_set.managed_policy_arns : {
+        permission_set_name = permission_set_name
+        managed_policy_arn  = managed_policy_arn
+      }
+    ]
+  ])
   iam_activity = {
     SSO = "{$.readOnly IS FALSE && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\"}"
   }

--- a/sso.tf
+++ b/sso.tf
@@ -18,7 +18,7 @@ resource "aws_ssoadmin_account_assignment" "default" {
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "default" {
-  for_each           = { for permission_set_name, permission_set in var.aws_sso_permission_sets: permission_set_name => permission_set if permission_set.inline_policy != "" }
+  for_each           = { for permission_set_name, permission_set in var.aws_sso_permission_sets : permission_set_name => permission_set if permission_set.inline_policy != "" }
   inline_policy      = each.value.inline_policy
   instance_arn       = aws_ssoadmin_permission_set.default[each.key].instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.default[each.key].arn

--- a/sso.tf
+++ b/sso.tf
@@ -18,7 +18,7 @@ resource "aws_ssoadmin_account_assignment" "default" {
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "default" {
-  for_each           = var.aws_sso_permission_sets
+  for_each           = { for permission_set_name, permission_set in var.aws_sso_permission_sets: permission_set_name => permission_set if permission_set.inline_policy != "" }
   inline_policy      = each.value.inline_policy
   instance_arn       = aws_ssoadmin_permission_set.default[each.key].instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.default[each.key].arn

--- a/sso.tf
+++ b/sso.tf
@@ -23,3 +23,10 @@ resource "aws_ssoadmin_permission_set_inline_policy" "default" {
   instance_arn       = aws_ssoadmin_permission_set.default[each.key].instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.default[each.key].arn
 }
+
+resource "aws_ssoadmin_managed_policy_attachment" "default" {
+  for_each           = { for assignment in local.aws_sso_managed_policy_arn_assignment : "${assignment.permission_set_name}-${assignment.managed_policy_arn}" => assignment }
+  instance_arn       = aws_ssoadmin_permission_set.default[each.value.permission_set_name].instance_arn
+  managed_policy_arn = each.value.managed_policy_arn
+  permission_set_arn = aws_ssoadmin_permission_set.default[each.value.permission_set_name].arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -138,9 +138,10 @@ variable "security_hub_create_cis_metric_filters" {
 
 variable "aws_sso_permission_sets" {
   type = map(object({
-    assignments      = list(map(list(string)))
-    inline_policy    = string
-    session_duration = string
+    assignments         = list(map(list(string)))
+    inline_policy       = string
+    managed_policy_arns = list(string)
+    session_duration    = string
   }))
   default     = {}
   description = "Map of AWS SSO Permission Sets with the AWS Accounts and the names of the AWS SSO Groups that should be granted access to each account"


### PR DESCRIPTION
This PR adds support for managed policy ARN's in SSO permission sets. Using only inline policies you can only have a single policy with a limited length. AWS provides a lot of managed policies that can be used for trivial stuff instead of having to specify and maintain your own policies. Use with care.