### PR TITLE
upgraded usage of datadog module to v0.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ module "landing_zone" {
 | aws\_security\_hub\_sns\_subscription | Subscription options for the LandingZone-SecurityHubFindings SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | aws\_sso\_permission\_sets | Map of AWS SSO Permission Sets with the AWS Accounts and the names of the AWS SSO Groups that should be granted access to each account | <pre>map(object({<br>    assignments         = list(map(list(string)))<br>    inline_policy       = string<br>    managed_policy_arns = list(string)<br>    session_duration    = string<br>  }))</pre> | `{}` | no |
 | datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
+| datadog\_excluded\_regions | List of regions where metrics collection will be disabled. | `list(string)` | `[]` | no |
 | kms\_key\_policy | A valid KMS key policy JSON document | `string` | `""` | no |
 | monitor\_iam\_activity | Whether IAM activity should be monitored | `bool` | `true` | no |
 | monitor\_iam\_activity\_sns\_subscription | Subscription options for the LandingZone-IAMActivity SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |

--- a/audit.tf
+++ b/audit.tf
@@ -211,9 +211,10 @@ resource "aws_sns_topic_subscription" "security_hub_findings" {
 // Monitoring
 module "datadog_audit" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
-  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.7"
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.8"
   providers             = { aws = aws.audit }
   api_key               = try(var.datadog.api_key, null)
+  excluded_regions      = var.datadog_excluded_regions
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
 }

--- a/logging.tf
+++ b/logging.tf
@@ -49,9 +49,10 @@ resource "aws_config_aggregate_authorization" "logging" {
 
 module "datadog_logging" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
-  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.7"
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.8"
   providers             = { aws = aws.logging }
   api_key               = try(var.datadog.api_key, null)
+  excluded_regions      = var.datadog_excluded_regions
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   tags                  = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -105,8 +105,9 @@ resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
 
 module "datadog_master" {
   count                 = try(var.datadog.enable_integration, false) == true ? 1 : 0
-  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.7"
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-datadog?ref=v0.3.8"
   api_key               = try(var.datadog.api_key, null)
+  excluded_regions      = var.datadog_excluded_regions
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
   site_url              = try(var.datadog.site_url, null)
   tags                  = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "datadog" {
   description = "Datadog integration options for the core accounts"
 }
 
+variable "datadog_excluded_regions" {
+  type        = list(string)
+  description = "List of regions where metrics collection will be disabled."
+  default     = []
+}
+
 variable "kms_key_policy" {
   type        = string
   default     = ""


### PR DESCRIPTION
This is to add support for datadog_excluded_regions variable. Using this variable, we can disable metrics collection for specified regions. 