### PR TITLE
Add support for providing secure mailboxes/IT service catalog aliases for all root accounts using Amazon SES/Lambda. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.14.1 (2022-02-16)
+- Add support for providing secure mailboxes/IT service catalog aliases for all root accounts using Amazon SES/Lambda. Adding the `ses_root_accounts_mail_alias` variable creates the necessary resources to accept mail sent to a verified email address and forward it to an external recipient or recipients
+
+
 ## 0.14.0 (2022-01-14)
 
 - Add an account level S3 public access policy to block public access to all S3 buckets within the landing zone core accounts. ([#125](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/125))

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ module "landing_zone" {
 | monitor\_iam\_activity\_sns\_subscription | Subscription options for the LandingZone-IAMActivity SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | security\_hub\_create\_cis\_metric\_filters | Enable the creation of metric filters related to the CIS AWS Foundation Security Hub Standard | `bool` | `true` | no |
 | security\_hub\_standards\_arns | A list of the ARNs of the standards you want to enable in Security Hub | `list(string)` | `null` | no |
+| ses\_root\_accounts\_mail\_alias | Provides a root accounts mail alias and forwarding service | <pre>map(object({<br>    domain            = string<br>    from_email        = string<br>    recipient_mapping = map(any)<br>  }))</pre> | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ module "landing_zone" {
 
 # Detailed configuration
 
+## AWS SES Accounts mail alias
+By setting the `ses_root_accounts_mail_alias` variable you can enable secure mailboxes/IT service catalog aliases for all root accounts and forward it to an external recipient or recipients. Emails are received via AWS Simple Email Service (SES) and forwarded to an email forwarder lambda which sends the email to the destination email server as specified in the `recipient_mapping` variable of `ses_root_accounts_mail_alias`.
+
+Before setting the `ses_root_accounts_mail_alias` variable, make sure that an AWS Route53 hosted zone is created. For example aws.yourcompany.com. Pass this domain using the `domain` variable of `ses_root_accounts_mail_alias`.
+
+Example:
+
+```hcl
+ses_root_accounts_mail_alias = {
+  domain   = "aws.yourcompany.com"
+  from_email = "int@aws.yourcompany.com"
+  recipient_mapping = {
+    "int@aws.yourcompany.com" = [
+      "inbox@yourcompany.com"
+    ]
+  }
+}
+```
+By default, you have to create the email addresses for the accounts created using the [MCAF Account Vending Machine (AVM) module](https://github.com/schubergphilis/terraform-aws-mcaf-avm) yourself. Using this functionality you can pass aliases of the mailbox created. E.g. int+\<account-name\>@aws.yourcompany.com. 
+
 ## AWS CloudTrail
 
 By default, all CloudTrail logs will be stored in a S3 bucket in the `logging` account of your AWS Organization. However, this module also supports creating an additional CloudTrail configuration to publish logs to any S3 bucket chosen by you. This trail will be set at the Organization level, meaning that logs from all accounts will be published to the provided bucket.

--- a/ses_accounts_mail_alias.tf
+++ b/ses_accounts_mail_alias.tf
@@ -1,0 +1,21 @@
+module "ses-root-accounts-mail-alias" {
+  count     = var.ses_root_accounts_mail_alias != null ? 1 : 0
+  providers = { aws = aws, aws.route53 = aws }
+
+  source     = "github.com/schubergphilis/terraform-aws-mcaf-ses?ref=v0.1.0"
+  domain     = var.ses_root_accounts_mail_alias.domain
+  kms_key_id = module.kms_key.id
+  tags       = var.tags
+}
+
+module "ses-forwarder-root-accounts-mail-alias" {
+  count     = var.ses_root_accounts_mail_alias != null ? 1 : 0
+  providers = { aws = aws, aws.lambda = aws }
+
+  source            = "github.com/schubergphilis/terraform-aws-mcaf-ses-forwarder?ref=v0.1.1"
+  bucket_name       = "ses-forwarder-${replace(var.ses_root_accounts_alias.domain, ".", "-")}"
+  from_email        = var.ses_root_accounts_mail_alias.from_email
+  kms_key_id        = module.kms_key.id
+  recipient_mapping = var.ses_root_accounts_mail_alias.recipient_mapping
+  tags              = var.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -193,6 +193,16 @@ variable "monitor_iam_activity_sns_subscription" {
   description = "Subscription options for the LandingZone-IAMActivity SNS topic"
 }
 
+variable "ses_root_accounts_mail_alias" {
+  type = map(object({
+    domain            = string
+    from_email        = string
+    recipient_mapping = map(any)
+  }))
+  default     = null
+  description = "Provides a root accounts mail alias and forwarding service"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Map of tags"


### PR DESCRIPTION
Add support for providing secure mailboxes/IT service catalog aliases for all root accounts using Amazon SES/Lambda. Adding the `ses_root_accounts_mail_alias` variable creates the necessary resources to accept mail sent to a verified email address and forward it to an external recipient or recipients