### PR TITLE
Updated KMS key policy in logging account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.15.2 (2022-03-14)
+
+ENHANCEMENTS
+
+- Updated KMS key policy for logging KMS key have more default Get permissions([#130](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/129))
+
 ## 0.15.1 (2022-03-10)
 
 ENHANCEMENTS

--- a/logging.tf
+++ b/logging.tf
@@ -145,8 +145,8 @@ data "aws_iam_policy_document" "kms_key_logging" {
     sid = "List KMS keys permissions for all IAM users"
     actions = [
       "kms:Describe*",
-      "kms:ListAliases",
-      "kms:ListKeys"
+      "kms:Get*",
+      "kms:List*"
     ]
     effect    = "Allow"
     resources = ["*"]


### PR DESCRIPTION
We need to update the default policy for KMS key so all users can list the key and see its policy. 