### PR TITLE
Add site URL to audit and logging datadog modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.15.4 (2022-04-15)
+
+BUG FIXES
+
+- Datadog site url is now also passed to datadog forwarder module for audit and logging accounts. ([#133](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/133))
+
 ## 0.15.3 (2022-04-05)
 
 BUG FIXES

--- a/audit.tf
+++ b/audit.tf
@@ -216,6 +216,7 @@ module "datadog_audit" {
   api_key               = try(var.datadog.api_key, null)
   excluded_regions      = var.datadog_excluded_regions
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
+  site_url              = try(var.datadog.site_url, null)
   tags                  = var.tags
 }
 

--- a/logging.tf
+++ b/logging.tf
@@ -54,6 +54,7 @@ module "datadog_logging" {
   api_key               = try(var.datadog.api_key, null)
   excluded_regions      = var.datadog_excluded_regions
   install_log_forwarder = try(var.datadog.install_log_forwarder, false)
+  site_url              = try(var.datadog.site_url, null)
   tags                  = var.tags
 }
 


### PR DESCRIPTION
The site url for the datadog forwarder was only passed on to the datadog module for the org account. This caused the forwarder to use the `.eu` endpoint for the audit and logging accounts, which (in our case) is not there or not configured.

This change makes the logging and audit accounts also respect the site url.