### PR TITLE
feature/whitelist-sustainability-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.15.5 (2022-05-31)
+
+ENHANCEMENTS
+
+- Whitelist Sustainability as a approved global service in the Allowed Regions Service Control Policy. ([#133](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/134))
+
 ## 0.15.4 (2022-04-15)
 
 BUG FIXES

--- a/files/organizations/allowed_regions.json.tpl
+++ b/files/organizations/allowed_regions.json.tpl
@@ -44,6 +44,7 @@
                 "shield:*",
                 "sts:*",
                 "support:*",
+                "sustainability:*",
                 "trustedadvisor:*",
                 "waf-regional:*",
                 "waf:*",


### PR DESCRIPTION
Whitelist Sustainability as a approved global service in the Allowed Regions Service Control Policy
**Reference**: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/what-is-ccft.html