### PR TITLE
Update the terraform-aws-mcaf-ses module to v0.1.1 to support DMARC record creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.17.3 (2022-09-30)
+
+ENHANCEMENTS
+
+- Update the terraform-aws-mcaf-ses module to v0.1.1 to support DMARC record creation. ([#141](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/141))
+
 ## 0.17.2 (2022-08-12)
 
 BUG FIXES

--- a/ses_accounts_mail_alias.tf
+++ b/ses_accounts_mail_alias.tf
@@ -1,7 +1,7 @@
 module "ses-root-accounts-mail-alias" {
   count     = var.ses_root_accounts_mail_forward != null ? 1 : 0
   providers = { aws = aws, aws.route53 = aws }
-  source    = "github.com/schubergphilis/terraform-aws-mcaf-ses?ref=v0.1.0"
+  source    = "github.com/schubergphilis/terraform-aws-mcaf-ses?ref=v0.1.1"
 
   domain     = var.ses_root_accounts_mail_forward.domain
   kms_key_id = module.kms_key.id


### PR DESCRIPTION
This version of terraform-aws-mcaf-ses includes the DMARC record: https://github.com/schubergphilis/terraform-aws-mcaf-ses/pull/5