### PR TITLE
Update the terraform-aws-mcaf-ses module to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.17.4 (2022-10-05)
+
+ENHANCEMENTS
+
+- Update the terraform-aws-mcaf-ses module to v0.1.2 to support DMARC RUA and RUF reporting and wildcard SPF records. ([#143](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/143))
+
 ## 0.17.3 (2022-09-30)
 
 ENHANCEMENTS

--- a/ses_accounts_mail_alias.tf
+++ b/ses_accounts_mail_alias.tf
@@ -1,7 +1,7 @@
 module "ses-root-accounts-mail-alias" {
   count     = var.ses_root_accounts_mail_forward != null ? 1 : 0
   providers = { aws = aws, aws.route53 = aws }
-  source    = "github.com/schubergphilis/terraform-aws-mcaf-ses?ref=v0.1.1"
+  source    = "github.com/schubergphilis/terraform-aws-mcaf-ses?ref=v0.1.2"
 
   domain     = var.ses_root_accounts_mail_forward.domain
   kms_key_id = module.kms_key.id


### PR DESCRIPTION
Update the terraform-aws-mcaf-ses module to v0.1.2 to support DMARC RUA and RUF reporting and wildcard SPF records.