### PR TITLE
Update AWS ConfigRole to match the updated policy name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.17.6 (2022-10-13)
+
+BUG FIXES
+
+- Update AWS ConfigRole to match the updated policy name. ([#147](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/147))
+
 ## 0.17.5 (2022-10-13)
 
 BUG FIXES

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role_policy_attachment" "config_recorder_read_only" {
 
 resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
   role       = aws_iam_role.config_recorder.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 module "datadog_master" {


### PR DESCRIPTION
Use the updated service role policy name [as announced by AWS](https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/#:~:text=On%20July%205%2C%202022%2C%20the,users%2C%20groups%2C%20and%20roles).