### PR TITLE
Fixes CheckOV findings related to GuardDuty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.21.3 (2023-01-06)
+
+ENHANCEMENTS
+
+- Fixed CheckOV finding because of `aws_guardduty_detector` not explicity enabled ([#158](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/158)).
+
 ## 0.21.2 (2023-01-03)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -376,16 +376,16 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.3 |
-| aws | >= 4.9.0 |
+| aws | >= 4.40.0 |
 | mcaf | >= 0.4.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 4.9.0 |
-| aws.audit | >= 4.9.0 |
-| aws.logging | >= 4.9.0 |
+| aws | >= 4.40.0 |
+| aws.audit | >= 4.40.0 |
+| aws.logging | >= 4.40.0 |
 | mcaf | >= 0.4.2 |
 
 ## Inputs

--- a/audit.tf
+++ b/audit.tf
@@ -113,6 +113,7 @@ resource "aws_guardduty_organization_configuration" "default" {
 resource "aws_guardduty_detector" "audit" {
   count    = var.aws_guardduty == true ? 1 : 0
   provider = aws.audit
+  enable   = true
   tags     = var.tags
 
   datasources {


### PR DESCRIPTION
We need to explicitly enable the `guardduty_detector` resource.