### PR TITLE
Add supportplan:* to the DenyAllRegionsOutsideAllowedList SCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ENHANCEMENTS
 
-- Adding the `supportplan:*` global service as exception to the `DenyAllRegionsOutsideAllowedList` SCP ([#159](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/159)).
+- Adding the `supportplans:*` global service as exception to the `DenyAllRegionsOutsideAllowedList` SCP ([#159](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/159)).
 
 ## 0.21.3 (2023-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.21.4 (2023-01-09)
+
+ENHANCEMENTS
+
+- Adding the `supportplan:*` global service as exception to the `DenyAllRegionsOutsideAllowedList` SCP ([#159](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/159)).
+
 ## 0.21.3 (2023-01-06)
 
 ENHANCEMENTS

--- a/files/organizations/allowed_regions.json.tpl
+++ b/files/organizations/allowed_regions.json.tpl
@@ -62,6 +62,7 @@
                 "shield:*",
                 "sts:*",
                 "support:*",
+                "supportplans:*",
                 "sustainability:*",
                 "trustedadvisor:*",
                 "waf-regional:*",


### PR DESCRIPTION
This is needed for allowing account to switch support plans per: https://docs.aws.amazon.com/awssupport/latest/user/security-support-plans.html?icmpid=docs_support_plans_console