### PR TITLE
Extend GuardDuty functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ENHANCEMENTS
 
-- Make GuardDuty finding publishing frequency configurable ([#162](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/162)).
+- Make GuardDuty more configurable, adds ability to set publishing frequency and data sources ([#161](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/161)).
 
 ## 0.21.5 (2023-01-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.22.0 (2023-01-18)
+
+ENHANCEMENTS
+
+- Make GuardDuty finding publishing frequency configurable ([#162](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/162)).
+
 ## 0.21.5 (2023-01-11)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ aws_config = {
 
 ### AWS GuardDuty
 
-This module supports enabling GuardDuty at the organization level which means that all new accounts that are created in, or added to, the organization are added as a member accounts of the `audit` account GuardDuty detector.
+This module supports enabling GuardDuty at the organization level which means that all new accounts that are created in, or added to, the organization are added as member accounts to the `audit` account GuardDuty detector.
 
-This feature can be controlled via the `aws_guardduty` variable and is enabled by default. With `aws_guardduty_s3_protection` you control if you want to have GuardDuty protecting S3, it is turned on by default.
+The feature can be controlled via the `aws_guardduty` variable and is enabled by default. The finding publishing frequency has been reduced from 6 hours to every 15 minutes, and the Malware Protection, Kubernetes and S3 Logs data sources are enabled out of the box.
 
 Note: In case you are migrating an existing AWS organization to this module, all existing accounts except for the `master` and `logging` accounts have to be enabled like explained [here](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html#guardduty_add_orgs_accounts).
 

--- a/README.md
+++ b/README.md
@@ -399,8 +399,7 @@ module "landing_zone" {
 | aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
 | aws\_config\_sns\_subscription | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | aws\_ebs\_encryption\_by\_default | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
-| aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
-| aws\_guardduty\_s3\_protection | Whether AWS GuardDuty S3 protection should be enabled | `bool` | `true` | no |
+| aws\_guardduty | AWS GuardDuty settings | <pre>object({<br>    enabled                      = optional(bool, true)<br>    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")<br>    datasources = object({<br>      malware_protection = optional(bool, true)<br>      kubernetes         = optional(bool, true)<br>      s3_logs            = optional(bool, true)<br>    })<br>  })</pre> | <pre>{<br>  "datasources": {<br>    "kubernetes": true,<br>    "malware_protection": true,<br>    "s3_logs": true<br>  },<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES"<br>}</pre> | no |
 | aws\_required\_tags | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
 | aws\_security\_hub\_product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |
 | aws\_security\_hub\_sns\_subscription | Subscription options for the LandingZone-SecurityHubFindings SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |

--- a/audit.tf
+++ b/audit.tf
@@ -96,30 +96,50 @@ resource "aws_sns_topic_subscription" "aws_config" {
   topic_arn              = "arn:aws:sns:${data.aws_region.current.name}:${var.control_tower_account_ids.audit}:aws-controltower-AggregateSecurityNotifications"
 }
 
-// Guardduty
+// GuardDuty
 resource "aws_guardduty_organization_admin_account" "audit" {
-  count            = var.aws_guardduty == true ? 1 : 0
+  count            = var.aws_guardduty.enabled == true ? 1 : 0
   admin_account_id = var.control_tower_account_ids.audit
 }
 
 resource "aws_guardduty_organization_configuration" "default" {
-  count       = var.aws_guardduty == true ? 1 : 0
+  count       = var.aws_guardduty.enabled == true ? 1 : 0
   provider    = aws.audit
-  auto_enable = true
-  detector_id = aws_guardduty_detector.audit[0].id
-  depends_on  = [aws_guardduty_organization_admin_account.audit]
+  auto_enable = var.aws_guardduty.enabled
+  detector_id = aws_guardduty_detector.audit.id
+
+  datasources {
+    kubernetes {
+      audit_logs {
+        enable = var.aws_guardduty.datasources.kubernetes
+      }
+    }
+
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          auto_enable = var.aws_guardduty.datasources.malware_protection
+        }
+      }
+    }
+
+    s3_logs {
+      auto_enable = var.aws_guardduty.datasources.s3_logs
+    }
+  }
+
+  depends_on = [aws_guardduty_organization_admin_account.audit]
 }
 
 resource "aws_guardduty_detector" "audit" {
-  count                        = var.aws_guardduty == true ? 1 : 0
   provider                     = aws.audit
-  enable                       = true
-  finding_publishing_frequency = var.aws_guardduty_finding_publishing_frequency
+  enable                       = var.aws_guardduty.enabled
+  finding_publishing_frequency = var.aws_guardduty.finding_publishing_frequency
   tags                         = var.tags
 
   datasources {
     s3_logs {
-      enable = var.aws_guardduty_s3_protection
+      enable = true
     }
   }
 }

--- a/audit.tf
+++ b/audit.tf
@@ -111,10 +111,11 @@ resource "aws_guardduty_organization_configuration" "default" {
 }
 
 resource "aws_guardduty_detector" "audit" {
-  count    = var.aws_guardduty == true ? 1 : 0
-  provider = aws.audit
-  enable   = true
-  tags     = var.tags
+  count                        = var.aws_guardduty == true ? 1 : 0
+  provider                     = aws.audit
+  enable                       = true
+  finding_publishing_frequency = var.aws_guardduty_finding_publishing_frequency
+  tags                         = var.tags
 
   datasources {
     s3_logs {

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "aws_guardduty" {
   description = "Whether AWS GuardDuty should be enabled"
 }
 
+variable "aws_guardduty_finding_publishing_frequency" {
+  type        = string
+  default     = "FIFTEEN_MINUTES"
+  description = "Specifies the frequency of notifications sent for subsequent finding occurrences"
+}
+
 variable "aws_guardduty_s3_protection" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -56,21 +56,25 @@ variable "aws_ebs_encryption_by_default" {
 }
 
 variable "aws_guardduty" {
-  type        = bool
-  default     = true
-  description = "Whether AWS GuardDuty should be enabled"
-}
-
-variable "aws_guardduty_finding_publishing_frequency" {
-  type        = string
-  default     = "FIFTEEN_MINUTES"
-  description = "Specifies the frequency of notifications sent for subsequent finding occurrences"
-}
-
-variable "aws_guardduty_s3_protection" {
-  type        = bool
-  default     = true
-  description = "Whether AWS GuardDuty S3 protection should be enabled"
+  type = object({
+    enabled                      = optional(bool, true)
+    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")
+    datasources = object({
+      malware_protection = optional(bool, true)
+      kubernetes         = optional(bool, true)
+      s3_logs            = optional(bool, true)
+    })
+  })
+  default = {
+    enabled                      = true
+    finding_publishing_frequency = "FIFTEEN_MINUTES"
+    datasources = {
+      malware_protection = true
+      kubernetes         = true
+      s3_logs            = true
+    }
+  }
+  description = "AWS GuardDuty settings"
 }
 
 variable "aws_required_tags" {


### PR DESCRIPTION
### Make GuardDuty data sources configurable

Data sources should be configurable and come with sane defaults. This enabled S3 Logs and Kubernetes and leaves Malware Protection disabled.

### Make GuardDuty finding publishing frequency configurable

By default this is 6 hours and this is too long to push alerts. This makes it configurable and sets the default frequency to every 15 minutes.