### PR TITLE
Make GuardDuty finding publishing frequency configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.22.0 (2023-01-18)
+
+ENHANCEMENTS
+
+- Make GuardDuty finding publishing frequency configurable ([#162](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/162)).
+
 ## 0.21.5 (2023-01-11)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ module "landing_zone" {
 | aws\_config\_sns\_subscription | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | aws\_ebs\_encryption\_by\_default | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
 | aws\_guardduty | Whether AWS GuardDuty should be enabled | `bool` | `true` | no |
+| aws\_guardduty\_finding\_publishing\_frequency | Specifies the frequency of notifications sent for subsequent finding occurrences | `string` | `"FIFTEEN_MINUTES"` | no |
 | aws\_guardduty\_s3\_protection | Whether AWS GuardDuty S3 protection should be enabled | `bool` | `true` | no |
 | aws\_required\_tags | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
 | aws\_security\_hub\_product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |

--- a/audit.tf
+++ b/audit.tf
@@ -111,10 +111,11 @@ resource "aws_guardduty_organization_configuration" "default" {
 }
 
 resource "aws_guardduty_detector" "audit" {
-  count    = var.aws_guardduty == true ? 1 : 0
-  provider = aws.audit
-  enable   = true
-  tags     = var.tags
+  count                        = var.aws_guardduty == true ? 1 : 0
+  provider                     = aws.audit
+  enable                       = true
+  finding_publishing_frequency = var.aws_guardduty_finding_publishing_frequency
+  tags                         = var.tags
 
   datasources {
     s3_logs {

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "aws_guardduty" {
   description = "Whether AWS GuardDuty should be enabled"
 }
 
+variable "aws_guardduty_finding_publishing_frequency" {
+  type        = string
+  default     = "FIFTEEN_MINUTES"
+  description = "Specifies the frequency of notifications sent for subsequent finding occurrences"
+}
+
 variable "aws_guardduty_s3_protection" {
   type        = bool
   default     = true


### PR DESCRIPTION
By default this is 6 hours and this is too long to push alerts. This makes it configurable and sets the default frequency to every 15 minutes.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
