### PR TITLE
Use a seperate bucket to store AWS Config Configuration History, enable KMS on the delivery channel objects, and add the option to set a optional path for all supported IAM resources.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,17 +47,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-        continue-on-error: true # added this to prevent a PR from a remote fork failing the workflow
-      - name: Update module usage docs and push any changes back to PR branch
-        uses: Dirrk/terraform-docs@v1.0.8
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@v1.0.0
         with:
-          tf_docs_args: "--sort-inputs-by-required"
-          tf_docs_git_commit_message: "terraform-docs: Update module usage"
-          tf_docs_git_push: "true"
-          tf_docs_output_file: README.md
-          tf_docs_output_method: inject
-          tf_docs_find_dir: .
-        continue-on-error: true # added this to prevent a PR from a remote fork failing the workflow
+          args: --sort-by required
+          git-commit-message: Update module usage (terraform-docs)
+          git-push: true
+          output-file: README.md
+          output-method: inject
+        continue-on-error: true # added this to prevent a PR from a remote fork failing the workfloww
 
   tfsec:
     runs-on: ubuntu-latest
@@ -65,7 +63,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform pr commenter
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.0.2
+        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           tfsec_args: --concise-output
           github_token: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.23.0 (2023-02-01)
+
+ENHANCEMENTS
+
+- Use a seperate bucket to store AWS Config Configuration History, enable KMS on the delivery channel objects, and add the option to set a optional path for all supported IAM resources. ([#164](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/164)).
+- Restructure module - create a file per provided functionality instead of per account ([#163](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/163)).
+
 ## 0.22.0 (2023-01-18)
 
 ENHANCEMENTS

--- a/README.md
+++ b/README.md
@@ -375,59 +375,146 @@ module "landing_zone" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 1.3 |
-| aws | >= 4.40.0 |
-| mcaf | >= 0.4.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
+| <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 4.40.0 |
-| aws.audit | >= 4.40.0 |
-| aws.logging | >= 4.40.0 |
-| mcaf | >= 0.4.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 4.40.0 |
+| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 4.40.0 |
+| <a name="provider_mcaf"></a> [mcaf](#provider\_mcaf) | >= 0.4.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_config_s3"></a> [aws\_config\_s3](#module\_aws\_config\_s3) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.7.0 |
+| <a name="module_aws_sso_permission_sets"></a> [aws\_sso\_permission\_sets](#module\_aws\_sso\_permission\_sets) | ./modules/permission-set | n/a |
+| <a name="module_datadog_audit"></a> [datadog\_audit](#module\_datadog\_audit) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
+| <a name="module_datadog_logging"></a> [datadog\_logging](#module\_datadog\_logging) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
+| <a name="module_datadog_master"></a> [datadog\_master](#module\_datadog\_master) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
+| <a name="module_kms_key_audit"></a> [kms\_key\_audit](#module\_kms\_key\_audit) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
+| <a name="module_kms_key_logging"></a> [kms\_key\_logging](#module\_kms\_key\_logging) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
+| <a name="module_ses-root-accounts-mail-alias"></a> [ses-root-accounts-mail-alias](#module\_ses-root-accounts-mail-alias) | github.com/schubergphilis/terraform-aws-mcaf-ses | v0.1.3 |
+| <a name="module_ses-root-accounts-mail-forward"></a> [ses-root-accounts-mail-forward](#module\_ses-root-accounts-mail-forward) | github.com/schubergphilis/terraform-aws-mcaf-ses-forwarder | v0.2.3 |
+| <a name="module_tag_policy_assignment"></a> [tag\_policy\_assignment](#module\_tag\_policy\_assignment) | ./modules/tag-policy-assignment | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudtrail.additional_auditing_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
+| [aws_cloudwatch_event_rule.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_metric_filter.iam_activity_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_log_metric_filter.iam_activity_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_log_metric_filter.iam_activity_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.iam_activity_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.iam_activity_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.iam_activity_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_config_aggregate_authorization.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
+| [aws_config_aggregate_authorization.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
+| [aws_config_aggregate_authorization.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
+| [aws_config_aggregate_authorization.master_to_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
+| [aws_config_configuration_aggregator.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator) | resource |
+| [aws_config_configuration_recorder.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
+| [aws_config_configuration_recorder_status.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
+| [aws_config_delivery_channel.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
+| [aws_config_organization_managed_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_managed_rule) | resource |
+| [aws_ebs_encryption_by_default.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
+| [aws_ebs_encryption_by_default.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
+| [aws_ebs_encryption_by_default.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
+| [aws_guardduty_detector.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
+| [aws_guardduty_organization_admin_account.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_admin_account) | resource |
+| [aws_guardduty_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) | resource |
+| [aws_iam_account_password_policy.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+| [aws_iam_account_password_policy.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+| [aws_iam_account_password_policy.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+| [aws_iam_role.config_recorder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.sns_feedback_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.config_recorder_config_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_organizations_policy.deny_root_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
+| [aws_organizations_policy.lz_root_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
+| [aws_organizations_policy_attachment.deny_root_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
+| [aws_organizations_policy_attachment.lz_root_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
+| [aws_s3_account_public_access_block.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
+| [aws_s3_account_public_access_block.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
+| [aws_s3_account_public_access_block.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
+| [aws_securityhub_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
+| [aws_securityhub_organization_admin_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_admin_account) | resource |
+| [aws_securityhub_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_configuration) | resource |
+| [aws_securityhub_product_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_product_subscription) | resource |
+| [aws_securityhub_standards_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) | resource |
+| [aws_sns_topic.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_policy.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.aws_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_sns_topic_subscription.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_sns_topic_subscription.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_caller_identity.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_group.cloudtrail_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_cloudwatch_log_group.cloudtrail_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_cloudwatch_log_group.cloudtrail_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_iam_policy_document.aws_config_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [aws_organizations_organizational_units.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organizational_units) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_sns_topic.all_config_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+| [mcaf_aws_all_organizational_units.default](https://registry.terraform.io/providers/schubergphilis/mcaf/latest/docs/data-sources/aws_all_organizational_units) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| control\_tower\_account\_ids | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
-| tags | Map of tags | `map(string)` | n/a | yes |
-| additional\_auditing\_trail | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
-| aws\_account\_password\_policy | AWS account password policy parameters for the audit, logging and master account | <pre>object({<br>    allow_users_to_change        = bool<br>    max_age                      = number<br>    minimum_length               = number<br>    require_lowercase_characters = bool<br>    require_numbers              = bool<br>    require_symbols              = bool<br>    require_uppercase_characters = bool<br>    reuse_prevention_history     = number<br>  })</pre> | <pre>{<br>  "allow_users_to_change": true,<br>  "max_age": 90,<br>  "minimum_length": 14,<br>  "require_lowercase_characters": true,<br>  "require_numbers": true,<br>  "require_symbols": true,<br>  "require_uppercase_characters": true,<br>  "reuse_prevention_history": 24<br>}</pre> | no |
-| aws\_config | AWS Config settings | <pre>object({<br>    aggregator_account_ids = list(string)<br>    aggregator_regions     = list(string)<br>  })</pre> | `null` | no |
-| aws\_config\_sns\_subscription | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
-| aws\_ebs\_encryption\_by\_default | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
-| aws\_guardduty | AWS GuardDuty settings | <pre>object({<br>    enabled                      = optional(bool, true)<br>    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")<br>    datasources = object({<br>      malware_protection = optional(bool, true)<br>      kubernetes         = optional(bool, true)<br>      s3_logs            = optional(bool, true)<br>    })<br>  })</pre> | <pre>{<br>  "datasources": {<br>    "kubernetes": true,<br>    "malware_protection": true,<br>    "s3_logs": true<br>  },<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES"<br>}</pre> | no |
-| aws\_required\_tags | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
-| aws\_security\_hub\_product\_arns | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |
-| aws\_security\_hub\_sns\_subscription | Subscription options for the LandingZone-SecurityHubFindings SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
-| aws\_service\_control\_policies | AWS SCP's parameters to disable required/denied policies, set a list of allowed AWS regions, and set principals that are exempt from the restriction | <pre>object({<br>    allowed_regions                 = optional(list(string), [])<br>    aws_deny_disabling_security_hub = optional(bool, true)<br>    aws_deny_leaving_org            = optional(bool, true)<br>    aws_deny_root_user_ous          = optional(list(string), [])<br>    aws_require_imdsv2              = optional(bool, true)<br>    principal_exceptions            = optional(list(string), [])<br>  })</pre> | `{}` | no |
-| aws\_sso\_permission\_sets | Map of AWS IAM Identity Center permission sets with AWS accounts and group names that should be granted access to each account | <pre>map(object({<br>    assignments         = list(map(list(string)))<br>    inline_policy       = optional(string, null)<br>    managed_policy_arns = optional(list(string), [])<br>    session_duration    = optional(string, "PT4H")<br>  }))</pre> | `{}` | no |
-| datadog | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
-| datadog\_excluded\_regions | List of regions where metrics collection will be disabled. | `list(string)` | `[]` | no |
-| kms\_key\_policy | A list of valid KMS key policy JSON documents | `list(string)` | `[]` | no |
-| kms\_key\_policy\_audit | A list of valid KMS key policy JSON document for use with audit KMS key | `list(string)` | `[]` | no |
-| kms\_key\_policy\_logging | A list of valid KMS key policy JSON document for use with logging KMS key | `list(string)` | `[]` | no |
-| monitor\_iam\_activity | Whether IAM activity should be monitored | `bool` | `true` | no |
-| monitor\_iam\_activity\_sns\_subscription | Subscription options for the LandingZone-IAMActivity SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
-| security\_hub\_create\_cis\_metric\_filters | Enable the creation of metric filters related to the CIS AWS Foundation Security Hub Standard | `bool` | `true` | no |
-| security\_hub\_standards\_arns | A list of the ARNs of the standards you want to enable in Security Hub | `list(string)` | `null` | no |
-| ses\_root\_accounts\_mail\_forward | SES config to receive and forward root account emails | <pre>object({<br>    domain            = string<br>    from_email        = string<br>    recipient_mapping = map(any)<br><br>    dmarc = object({<br>      policy = optional(string)<br>      rua    = optional(string)<br>      ruf    = optional(string)<br>    })<br>  })</pre> | `null` | no |
+| <a name="input_control_tower_account_ids"></a> [control\_tower\_account\_ids](#input\_control\_tower\_account\_ids) | Control Tower core account IDs | <pre>object({<br>    audit   = string<br>    logging = string<br>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags | `map(string)` | n/a | yes |
+| <a name="input_additional_auditing_trail"></a> [additional\_auditing\_trail](#input\_additional\_auditing\_trail) | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name   = string<br>    bucket = string<br>  })</pre> | `null` | no |
+| <a name="input_aws_account_password_policy"></a> [aws\_account\_password\_policy](#input\_aws\_account\_password\_policy) | AWS account password policy parameters for the audit, logging and master account | <pre>object({<br>    allow_users_to_change        = bool<br>    max_age                      = number<br>    minimum_length               = number<br>    require_lowercase_characters = bool<br>    require_numbers              = bool<br>    require_symbols              = bool<br>    require_uppercase_characters = bool<br>    reuse_prevention_history     = number<br>  })</pre> | <pre>{<br>  "allow_users_to_change": true,<br>  "max_age": 90,<br>  "minimum_length": 14,<br>  "require_lowercase_characters": true,<br>  "require_numbers": true,<br>  "require_symbols": true,<br>  "require_uppercase_characters": true,<br>  "reuse_prevention_history": 24<br>}</pre> | no |
+| <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS Config settings | <pre>object({<br>    aggregator_account_ids          = optional(list(string), [])<br>    aggregator_regions              = optional(list(string), [])<br>    delivery_channel_s3_bucket_name = optional(string, null)<br>    delivery_channel_s3_key_prefix  = optional(string, null)<br>    delivery_frequency              = optional(string, "TwentyFour_Hours")<br>    rule_identifiers                = optional(list(string), [])<br>  })</pre> | <pre>{<br>  "aggregator_account_ids": [],<br>  "aggregator_regions": [],<br>  "delivery_channel_s3_bucket_name": null,<br>  "delivery_channel_s3_key_prefix": null,<br>  "delivery_frequency": "TwentyFour_Hours",<br>  "rule_identifiers": []<br>}</pre> | no |
+| <a name="input_aws_config_sns_subscription"></a> [aws\_config\_sns\_subscription](#input\_aws\_config\_sns\_subscription) | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
+| <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
+| <a name="input_aws_guardduty"></a> [aws\_guardduty](#input\_aws\_guardduty) | AWS GuardDuty settings | <pre>object({<br>    enabled                      = optional(bool, true)<br>    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")<br>    datasources = object({<br>      malware_protection = optional(bool, true)<br>      kubernetes         = optional(bool, true)<br>      s3_logs            = optional(bool, true)<br>    })<br>  })</pre> | <pre>{<br>  "datasources": {<br>    "kubernetes": true,<br>    "malware_protection": true,<br>    "s3_logs": true<br>  },<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES"<br>}</pre> | no |
+| <a name="input_aws_required_tags"></a> [aws\_required\_tags](#input\_aws\_required\_tags) | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
+| <a name="input_aws_security_hub_product_arns"></a> [aws\_security\_hub\_product\_arns](#input\_aws\_security\_hub\_product\_arns) | A list of the ARNs of the products you want to import into Security Hub | `list(string)` | `[]` | no |
+| <a name="input_aws_security_hub_sns_subscription"></a> [aws\_security\_hub\_sns\_subscription](#input\_aws\_security\_hub\_sns\_subscription) | Subscription options for the LandingZone-SecurityHubFindings SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
+| <a name="input_aws_service_control_policies"></a> [aws\_service\_control\_policies](#input\_aws\_service\_control\_policies) | AWS SCP's parameters to disable required/denied policies, set a list of allowed AWS regions, and set principals that are exempt from the restriction | <pre>object({<br>    allowed_regions                 = optional(list(string), [])<br>    aws_deny_disabling_security_hub = optional(bool, true)<br>    aws_deny_leaving_org            = optional(bool, true)<br>    aws_deny_root_user_ous          = optional(list(string), [])<br>    aws_require_imdsv2              = optional(bool, true)<br>    principal_exceptions            = optional(list(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_aws_sso_permission_sets"></a> [aws\_sso\_permission\_sets](#input\_aws\_sso\_permission\_sets) | Map of AWS IAM Identity Center permission sets with AWS accounts and group names that should be granted access to each account | <pre>map(object({<br>    assignments         = list(map(list(string)))<br>    inline_policy       = optional(string, null)<br>    managed_policy_arns = optional(list(string), [])<br>    session_duration    = optional(string, "PT4H")<br>  }))</pre> | `{}` | no |
+| <a name="input_datadog"></a> [datadog](#input\_datadog) | Datadog integration options for the core accounts | <pre>object({<br>    api_key               = string<br>    enable_integration    = bool<br>    install_log_forwarder = bool<br>    site_url              = string<br>  })</pre> | `null` | no |
+| <a name="input_datadog_excluded_regions"></a> [datadog\_excluded\_regions](#input\_datadog\_excluded\_regions) | List of regions where metrics collection will be disabled. | `list(string)` | `[]` | no |
+| <a name="input_kms_key_policy"></a> [kms\_key\_policy](#input\_kms\_key\_policy) | A list of valid KMS key policy JSON documents | `list(string)` | `[]` | no |
+| <a name="input_kms_key_policy_audit"></a> [kms\_key\_policy\_audit](#input\_kms\_key\_policy\_audit) | A list of valid KMS key policy JSON document for use with audit KMS key | `list(string)` | `[]` | no |
+| <a name="input_kms_key_policy_logging"></a> [kms\_key\_policy\_logging](#input\_kms\_key\_policy\_logging) | A list of valid KMS key policy JSON document for use with logging KMS key | `list(string)` | `[]` | no |
+| <a name="input_monitor_iam_activity"></a> [monitor\_iam\_activity](#input\_monitor\_iam\_activity) | Whether IAM activity should be monitored | `bool` | `true` | no |
+| <a name="input_monitor_iam_activity_sns_subscription"></a> [monitor\_iam\_activity\_sns\_subscription](#input\_monitor\_iam\_activity\_sns\_subscription) | Subscription options for the LandingZone-IAMActivity SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
+| <a name="input_path"></a> [path](#input\_path) | Optional path for all IAM users, user groups, roles, and customer managed policies created by this module | `string` | `"/"` | no |
+| <a name="input_security_hub_create_cis_metric_filters"></a> [security\_hub\_create\_cis\_metric\_filters](#input\_security\_hub\_create\_cis\_metric\_filters) | Enable the creation of metric filters related to the CIS AWS Foundation Security Hub Standard | `bool` | `true` | no |
+| <a name="input_security_hub_standards_arns"></a> [security\_hub\_standards\_arns](#input\_security\_hub\_standards\_arns) | A list of the ARNs of the standards you want to enable in Security Hub | `list(string)` | `null` | no |
+| <a name="input_ses_root_accounts_mail_forward"></a> [ses\_root\_accounts\_mail\_forward](#input\_ses\_root\_accounts\_mail\_forward) | SES config to receive and forward root account emails | <pre>object({<br>    domain            = string<br>    from_email        = string<br>    recipient_mapping = map(any)<br><br>    dmarc = object({<br>      policy = optional(string)<br>      rua    = optional(string)<br>      ruf    = optional(string)<br>    })<br>  })</pre> | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| kms\_key\_arn | ARN of KMS key for master account |
-| kms\_key\_audit\_arn | ARN of KMS key for audit account |
-| kms\_key\_audit\_id | ID of KMS key for audit account |
-| kms\_key\_id | ID of KMS key for master account |
-| kms\_key\_logging\_arn | ARN of KMS key for logging account |
-| kms\_key\_logging\_id | ID of KMS key for logging account |
-| monitor\_iam\_activity\_sns\_topic\_arn | ARN of the SNS Topic in the Audit account for IAM activity monitoring notifications |
-
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of KMS key for master account |
+| <a name="output_kms_key_audit_arn"></a> [kms\_key\_audit\_arn](#output\_kms\_key\_audit\_arn) | ARN of KMS key for audit account |
+| <a name="output_kms_key_audit_id"></a> [kms\_key\_audit\_id](#output\_kms\_key\_audit\_id) | ID of KMS key for audit account |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | ID of KMS key for master account |
+| <a name="output_kms_key_logging_arn"></a> [kms\_key\_logging\_arn](#output\_kms\_key\_logging\_arn) | ARN of KMS key for logging account |
+| <a name="output_kms_key_logging_id"></a> [kms\_key\_logging\_id](#output\_kms\_key\_logging\_id) | ID of KMS key for logging account |
+| <a name="output_monitor_iam_activity_sns_topic_arn"></a> [monitor\_iam\_activity\_sns\_topic\_arn](#output\_monitor\_iam\_activity\_sns\_topic\_arn) | ARN of the SNS Topic in the Audit account for IAM activity monitoring notifications |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ module "landing_zone" {
 }
 ```
 
-<!--- BEGIN_TF_DOCS --->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -428,7 +428,7 @@ module "landing_zone" {
 | kms\_key\_logging\_id | ID of KMS key for logging account |
 | monitor\_iam\_activity\_sns\_topic\_arn | ARN of the SNS Topic in the Audit account for IAM activity monitoring notifications |
 
-<!--- END_TF_DOCS --->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,8 +2,8 @@
 
 Version `0.23.x` introduces a change in behaviour of AWS Config:
 
-- By default the `aggregator_regions` were set to eu-west-1 and eu-central-1, this has been changed to only enable the current region. Please provide a list of regions to `var.aws_config.aggregator_regions` if you want to enable AWS Config in multiple regions.
-- The `aws-controltower-logs` bucket was used to store the CloudTrail and AWS Config logs. This version introduces a seperate bucket for AWS Config. You are able to override the bucket name to comply with naming rules of your organisation.
+- By default the `aggregator_regions` were set to eu-west-1 and eu-central-1, this has been changed to only enable the current region. Provide a list of regions to `var.aws_config.aggregator_regions` if you want to enable AWS Config in multiple regions.
+- Previously the `aws-controltower-logs` bucket was used to store CloudTrail and AWS Config logs, this version introduces a separate bucket for AWS Config. You are able to override the bucket name by setting `var.aws_config.delivery_channel_s3_bucket_name`.
 
 
 # Upgrading to 0.21.x

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,11 @@
+# Upgrading to 0.23.x
+
+Version `0.23.x` introduces a change in behaviour of AWS Config:
+
+- By default the `aggregator_regions` were set to eu-west-1 and eu-central-1, this has been changed to only enable the current region. Please provide a list of regions to `var.aws_config.aggregator_regions` if you want to enable AWS Config in multiple regions.
+- The `aws-controltower-logs` bucket was used to store the CloudTrail and AWS Config logs. This version introduces a seperate bucket for AWS Config. You are able to override the bucket name to comply with naming rules of your organisation.
+
+
 # Upgrading to 0.21.x
 
 Version `0.21.x` introduces exceptions for IAM entities on the `DenyDisablingSecurityHub` and `DenyLeavingOrg` SCP. The following variables have been merged into a new variable `aws_service_control_policies`:

--- a/config.tf
+++ b/config.tf
@@ -1,3 +1,24 @@
+locals {
+  aws_config_aggregators = flatten([
+    for account in toset(try(var.aws_config.aggregator_account_ids, [])) : [
+      for region in toset(try(var.aws_config.aggregator_regions, [])) : {
+        account_id = account
+        region     = region
+      }
+    ]
+  ])
+  aws_config_rules = setunion(
+    try(var.aws_config.rule_identifiers, []),
+    [
+      "CLOUD_TRAIL_ENABLED",
+      "ENCRYPTED_VOLUMES",
+      "ROOT_ACCOUNT_MFA_ENABLED",
+      "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+    ]
+  )
+  aws_config_s3_name = coalesce(var.aws_config.delivery_channel_s3_bucket_name, "aws-config-configuration-history-${var.control_tower_account_ids.logging}-${data.aws_region.current.name}")
+}
+
 // AWS Config - Management account configuration
 resource "aws_config_aggregate_authorization" "master" {
   for_each = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator if aggregator.account_id != var.control_tower_account_ids.audit }
@@ -8,11 +29,26 @@ resource "aws_config_aggregate_authorization" "master" {
 }
 
 resource "aws_config_aggregate_authorization" "master_to_audit" {
-  for_each = toset(try(var.aws_config.aggregator_regions, ["eu-central-1", "eu-west-1"]))
+  for_each = toset(coalescelist(var.aws_config.aggregator_regions, [data.aws_region.current.name]))
 
   account_id = var.control_tower_account_ids.audit
   region     = each.value
   tags       = var.tags
+}
+
+resource "aws_iam_role" "config_recorder" {
+  name = "LandingZone-ConfigRecorderRole"
+  path = var.path
+  tags = var.tags
+
+  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {
+    service = "config.amazonaws.com"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
+  role       = aws_iam_role.config_recorder.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_config_configuration_recorder" "default" {
@@ -33,10 +69,16 @@ resource "aws_config_configuration_recorder_status" "default" {
 
 resource "aws_config_delivery_channel" "default" {
   name           = "default"
-  s3_bucket_name = "aws-controltower-logs-${var.control_tower_account_ids.logging}-${data.aws_region.current.name}"
-  s3_key_prefix  = data.aws_organizations_organization.default.id
+  s3_bucket_name = module.aws_config_s3.name
+  s3_key_prefix  = var.aws_config.delivery_channel_s3_key_prefix
+  s3_kms_key_arn = module.kms_key_logging.arn
   sns_topic_arn  = data.aws_sns_topic.all_config_notifications.arn
-  depends_on     = [aws_config_configuration_recorder.default]
+
+  snapshot_delivery_properties {
+    delivery_frequency = var.aws_config.delivery_frequency
+  }
+
+  depends_on = [aws_config_configuration_recorder.default]
 }
 
 resource "aws_config_organization_managed_rule" "default" {
@@ -44,25 +86,6 @@ resource "aws_config_organization_managed_rule" "default" {
 
   name            = each.value
   rule_identifier = each.value
-}
-
-resource "aws_iam_role" "config_recorder" {
-  name = "LandingZone-ConfigRecorderRole"
-  tags = var.tags
-
-  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {
-    service = "config.amazonaws.com"
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "config_recorder_read_only" {
-  role       = aws_iam_role.config_recorder.name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
-  role       = aws_iam_role.config_recorder.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 // AWS Config - Audit account configuration
@@ -107,4 +130,96 @@ resource "aws_config_aggregate_authorization" "logging" {
   account_id = each.value.account_id
   region     = each.value.region
   tags       = var.tags
+}
+
+data "aws_iam_policy_document" "aws_config_s3" {
+  statement {
+    sid = "AWSConfigBucketPermissionsCheck"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.aws_config_s3_name}"
+    ]
+  }
+
+  statement {
+    sid = "AWSConfigBucketExistenceCheck"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.aws_config_s3_name}"
+    ]
+  }
+
+  statement {
+    sid = "AllowConfigWriteAccess"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${local.aws_config_s3_name}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values = [
+        "bucket-owner-full-control"
+      ]
+    }
+  }
+}
+
+module "aws_config_s3" {
+  providers = { aws = aws.logging }
+
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.7.0"
+  name        = local.aws_config_s3_name
+  kms_key_arn = module.kms_key_logging.arn
+  policy      = data.aws_iam_policy_document.aws_config_s3.json
+  versioning  = true
+  tags        = var.tags
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 7
+      }
+
+      expiration = {
+        days = 365
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 365
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 90
+        storage_class   = "STANDARD_IA"
+      }
+
+      transition = {
+        days          = 90
+        storage_class = "STANDARD_IA"
+      }
+    }
+  ]
 }

--- a/iam_activity_logging.tf
+++ b/iam_activity_logging.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role" "sns_feedback" {
   provider = aws.audit
 
   name = "LandingZone-SNSFeedback"
+  path = var.path
   tags = var.tags
 
   assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {

--- a/kms.tf
+++ b/kms.tf
@@ -83,7 +83,10 @@ data "aws_iam_policy_document" "kms_key_audit" {
   }
 
   statement {
-    sid = "Administrative permissions for pipeline"
+    sid       = "Administrative permissions for pipeline"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+
     actions = [
       "kms:Create*",
       "kms:Describe*",
@@ -97,8 +100,6 @@ data "aws_iam_policy_document" "kms_key_audit" {
       "kms:UntagResource",
       "kms:Update*"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     principals {
       type = "AWS"
@@ -109,14 +110,15 @@ data "aws_iam_policy_document" "kms_key_audit" {
   }
 
   statement {
-    sid = "List KMS keys permissions for all IAM users"
+    sid       = "List KMS keys permissions for all IAM users"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+
     actions = [
       "kms:Describe*",
       "kms:Get*",
       "kms:List*"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     principals {
       type = "AWS"
@@ -127,13 +129,14 @@ data "aws_iam_policy_document" "kms_key_audit" {
   }
 
   statement {
-    sid = "Allow CloudWatch Decrypt"
+    sid       = "Allow CloudWatch Decrypt"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     principals {
       type = "Service"
@@ -145,13 +148,14 @@ data "aws_iam_policy_document" "kms_key_audit" {
   }
 
   statement {
-    sid = "Allow SNS Decrypt"
+    sid       = "Allow SNS Decrypt"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     principals {
       type = "Service"
@@ -198,7 +202,10 @@ data "aws_iam_policy_document" "kms_key_logging" {
   }
 
   statement {
-    sid = "Administrative permissions for pipeline"
+    sid       = "Administrative permissions for pipeline"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+
     actions = [
       "kms:Create*",
       "kms:Describe*",
@@ -211,8 +218,6 @@ data "aws_iam_policy_document" "kms_key_logging" {
       "kms:UntagResource",
       "kms:Update*"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     principals {
       type = "AWS"
@@ -223,14 +228,15 @@ data "aws_iam_policy_document" "kms_key_logging" {
   }
 
   statement {
-    sid = "List KMS keys permissions for all IAM users"
+    sid       = "List KMS keys permissions for all IAM users"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+
     actions = [
       "kms:Describe*",
       "kms:Get*",
       "kms:List*"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     principals {
       type = "AWS"
@@ -241,8 +247,10 @@ data "aws_iam_policy_document" "kms_key_logging" {
   }
 
   statement {
-    sid    = "KMS permissions for AWS logs service"
-    effect = "Allow"
+    sid       = "KMS permissions for AWS logs service"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+
     actions = [
       "kms:Encrypt",
       "kms:Decrypt",
@@ -250,7 +258,6 @@ data "aws_iam_policy_document" "kms_key_logging" {
       "kms:GenerateDataKey*",
       "kms:DescribeKey",
     ]
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     principals {
       type        = "Service"
@@ -259,13 +266,14 @@ data "aws_iam_policy_document" "kms_key_logging" {
   }
 
   statement {
-    sid = "AllowAWSConfigToEncryptDecryptLogs"
+    sid       = "AllowAWSConfigToEncryptDecryptLogs"
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+
     actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey*"
     ]
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     principals {
       type = "Service"

--- a/kms.tf
+++ b/kms.tf
@@ -257,4 +257,21 @@ data "aws_iam_policy_document" "kms_key_logging" {
       identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
     }
   }
+
+  statement {
+    sid = "AllowAWSConfigToEncryptDecryptLogs"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "config.amazonaws.com"
+      ]
+    }
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,22 +1,5 @@
 locals {
   aws_account_emails = { for account in data.aws_organizations_organization.default.accounts : account.id => account.email }
-  aws_config_aggregators = flatten([
-    for account in toset(try(var.aws_config.aggregator_account_ids, [])) : [
-      for region in toset(try(var.aws_config.aggregator_regions, [])) : {
-        account_id = account
-        region     = region
-      }
-    ]
-  ])
-  aws_config_rules = concat(
-    try(var.aws_config.rule_identifiers, []),
-    [
-      "CLOUD_TRAIL_ENABLED",
-      "ENCRYPTED_VOLUMES",
-      "ROOT_ACCOUNT_MFA_ENABLED",
-      "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
-    ]
-  )
   iam_activity = {
     SSO = "{$.readOnly IS FALSE && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\"}"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -33,11 +33,27 @@ variable "aws_account_password_policy" {
 
 variable "aws_config" {
   type = object({
-    aggregator_account_ids = list(string)
-    aggregator_regions     = list(string)
+    aggregator_account_ids          = optional(list(string), [])
+    aggregator_regions              = optional(list(string), [])
+    delivery_channel_s3_bucket_name = optional(string, null)
+    delivery_channel_s3_key_prefix  = optional(string, null)
+    delivery_frequency              = optional(string, "TwentyFour_Hours")
+    rule_identifiers                = optional(list(string), [])
   })
-  default     = null
+  default = {
+    aggregator_account_ids          = []
+    aggregator_regions              = []
+    delivery_channel_s3_bucket_name = null
+    delivery_channel_s3_key_prefix  = null
+    delivery_frequency              = "TwentyFour_Hours"
+    rule_identifiers                = []
+  }
   description = "AWS Config settings"
+
+  validation {
+    condition     = contains(["One_Hour", "Three_Hours", "Six_Hours", "Twelve_Hours", "TwentyFour_Hours"], var.aws_config.delivery_frequency)
+    error_message = "The delivery frequency must be set to \"One_Hour\", \"Three_Hours\", \"Six_Hours\", \"Twelve_Hours\", or \"TwentyFour_Hours\"."
+  }
 }
 
 variable "aws_config_sns_subscription" {
@@ -199,6 +215,12 @@ variable "monitor_iam_activity_sns_subscription" {
   }))
   default     = {}
   description = "Subscription options for the LandingZone-IAMActivity SNS topic"
+}
+
+variable "path" {
+  type        = string
+  default     = "/"
+  description = "Optional path for all IAM users, user groups, roles, and customer managed policies created by this module"
 }
 
 variable "ses_root_accounts_mail_forward" {


### PR DESCRIPTION
Changes:
- By default the `aggregator_regions` were set to eu-west-1 and eu-central-1, this has been changed to only enable the current region. A list of regions to `var.aws_config.aggregator_regions` can be provided to override this behaviour and enable AWS Config in multiple regions.
- The `aws-controltower-logs` bucket was used to store the CloudTrail and AWS Config logs. This PR introduces a seperate bucket for AWS Config. Its possible to overwrite the bucket name using `var.aws_config.delivery_channel_s3_bucket_name`.
- The AWS Config delivery channel and the S3 bucket are now encrypted using KMS out of the box.
- The variable `aws_config.rule_identifiers` has been put back, this was removed by accident in an earlier PR. 
- The ReadOnly role is removed from the config_recorder role, the `AWS_ConfigRole` is sufficient. 
- New: the option to set the delivery frequency using `aws_config.delivery_frequency`.
- New: the option to set the a path for all IAM users, user groups, roles, and customer managed policies created by this module.