### PR TITLE
fix: GuardDuty malware permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ module "landing_zone" {
 | <a name="module_datadog_audit"></a> [datadog\_audit](#module\_datadog\_audit) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
 | <a name="module_datadog_logging"></a> [datadog\_logging](#module\_datadog\_logging) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
 | <a name="module_datadog_master"></a> [datadog\_master](#module\_datadog\_master) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.11 |
+| <a name="module_guardduty_malware_protection_permissions"></a> [guardduty\_malware\_protection\_permissions](#module\_guardduty\_malware\_protection\_permissions) | digitickets/cli/aws | 5.0.4 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
 | <a name="module_kms_key_audit"></a> [kms\_key\_audit](#module\_kms\_key\_audit) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
 | <a name="module_kms_key_logging"></a> [kms\_key\_logging](#module\_kms\_key\_logging) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -5,6 +5,17 @@ resource "aws_guardduty_organization_admin_account" "audit" {
   admin_account_id = var.control_tower_account_ids.audit
 }
 
+// AWS GuardDuty - Allow the delegated administrator to enable malware permissions until https://github.com/hashicorp/terraform-provider-aws/issues/30475 is done
+module "guardduty_malware_protection_permissions" {
+  count    = var.aws_guardduty.enabled == true ? 1 : 0
+  
+  source           = "digitickets/cli/aws"
+  version          = "5.0.4"
+  aws_cli_commands = ["organizations", "enable-aws-service-access", "--service-principal malware-protection.guardduty.amazonaws.com"]
+  
+  depends_on = [aws_guardduty_organization_admin_account.audit]
+}
+
 // AWS GuardDuty - Audit account configuration
 resource "aws_guardduty_organization_configuration" "default" {
   count    = var.aws_guardduty.enabled == true ? 1 : 0

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -7,12 +7,12 @@ resource "aws_guardduty_organization_admin_account" "audit" {
 
 // AWS GuardDuty - Allow the delegated administrator to enable malware permissions until https://github.com/hashicorp/terraform-provider-aws/issues/30475 is done
 module "guardduty_malware_protection_permissions" {
-  count    = var.aws_guardduty.enabled == true ? 1 : 0
-  
+  count = var.aws_guardduty.enabled == true ? 1 : 0
+
   source           = "digitickets/cli/aws"
   version          = "5.0.4"
   aws_cli_commands = ["organizations", "enable-aws-service-access", "--service-principal malware-protection.guardduty.amazonaws.com"]
-  
+
   depends_on = [aws_guardduty_organization_admin_account.audit]
 }
 


### PR DESCRIPTION
Enables the delegation of GuardDuty Malware permissions through the CLI resource until the `aws_guardduty_organization_admin_account` resource supports it: https://github.com/hashicorp/terraform-provider-aws/issues/30475