### PR TITLE
enhancement: Enable SecurityHub for management and logging account

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.60.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | > 3.0.0 |
 | <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 
@@ -417,9 +417,9 @@ module "landing_zone" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40.0 |
-| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 4.40.0 |
-| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 4.40.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.60.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 4.60.0 |
+| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 4.60.0 |
 | <a name="provider_mcaf"></a> [mcaf](#provider\_mcaf) | >= 0.4.2 |
 
 ## Modules
@@ -481,6 +481,9 @@ module "landing_zone" {
 | [aws_s3_account_public_access_block.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_s3_account_public_access_block.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_securityhub_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
+| [aws_securityhub_account.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
+| [aws_securityhub_member.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_member) | resource |
+| [aws_securityhub_member.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_member) | resource |
 | [aws_securityhub_organization_admin_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_admin_account) | resource |
 | [aws_securityhub_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_configuration) | resource |
 | [aws_securityhub_product_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_product_subscription) | resource |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The module creates 3 AWS KMS keys, one for the master account, one for the audit
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.management.account_id}:root"
       ]
     }
   }
@@ -494,7 +494,7 @@ module "landing_zone" {
 | [aws_sns_topic_subscription.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudwatch_log_group.cloudtrail_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_cloudwatch_log_group.cloudtrail_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_cloudwatch_log_group.cloudtrail_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |

--- a/data.tf
+++ b/data.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "logging" {
   provider = aws.logging
 }
 
-data "aws_caller_identity" "master" {}
+data "aws_caller_identity" "management" {}
 
 data "aws_cloudwatch_log_group" "cloudtrail_audit" {
   count    = var.monitor_iam_activity ? 1 : 0

--- a/kms.tf
+++ b/kms.tf
@@ -15,12 +15,12 @@ data "aws_iam_policy_document" "kms_key" {
     sid       = "Base Permissions"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.master.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
 
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"
+        "arn:aws:iam::${data.aws_caller_identity.management.account_id}:root"
       ]
     }
   }
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "kms_key" {
     content {
       sid       = "Allow SES Decrypt"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.master.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
 
       actions = [
         "kms:Decrypt",
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "kms_key" {
     content {
       sid       = "Allow EmailForwarder CloudWatch Log Group"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.master.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
 
       actions = [
         "kms:Decrypt",
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "kms_key" {
         variable = "kms:EncryptionContext:aws:logs:arn"
 
         values = [
-          "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.master.account_id}:log-group:/aws/lambda/EmailForwarder"
+          "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:log-group:/aws/lambda/EmailForwarder"
         ]
       }
 

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -16,6 +16,36 @@ resource "aws_securityhub_organization_configuration" "default" {
   depends_on  = [aws_securityhub_organization_admin_account.default]
 }
 
+// AWS Security Hub - Management account enrollment
+resource "aws_securityhub_account" "management" {
+  depends_on = [aws_securityhub_organization_configuration.default]
+}
+
+resource "aws_securityhub_member" "management" {
+  provider = aws.audit
+
+  account_id = data.aws_caller_identity.management.account_id
+
+  lifecycle {
+    ignore_changes = [invite]
+  }
+
+  depends_on = [aws_securityhub_account.management]
+}
+
+// AWS Security Hub - Logging account enrollment
+resource "aws_securityhub_member" "logging" {
+  provider = aws.audit
+
+  account_id = data.aws_caller_identity.logging.account_id
+
+  lifecycle {
+    ignore_changes = [invite]
+  }
+
+  depends_on = [aws_securityhub_organization_configuration.default]
+}
+
 resource "aws_securityhub_product_subscription" "default" {
   for_each = toset(var.aws_security_hub_product_arns)
   provider = aws.audit

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.40.0"
+      version               = ">= 4.60.0"
       configuration_aliases = [aws.audit, aws.logging]
     }
     datadog = {


### PR DESCRIPTION
- The current code for SecurityHub configures enrollment for new accounts. The already existing management and logging accounts need to be enrolled as well.
- SecurityHub needs to be explicitly enabled in the management account before it can be added as a member in the audit account.
- Changed all the appearances of master to management for the aws_caller_identity resource
- Upgrading the AWS provider to [version v4.60.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.60.0), the `aws_securityhub_member` resource email variable has been made optional.

The ignore lifecycle statement is due to this bug: https://github.com/hashicorp/terraform-provider-aws/issues/24320