### PR TITLE
breaking: Add AWS Guardduty detector features & bump AWS provider to next major v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ module "landing_zone" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.60.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | > 3.0.0 |
 | <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 
@@ -431,9 +431,9 @@ module "landing_zone" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.60.0 |
-| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 4.60.0 |
-| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 4.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 5.21.0 |
+| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 5.21.0 |
 | <a name="provider_mcaf"></a> [mcaf](#provider\_mcaf) | >= 0.4.2 |
 
 ## Modules
@@ -480,6 +480,12 @@ module "landing_zone" {
 | [aws_guardduty_detector.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
 | [aws_guardduty_organization_admin_account.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_admin_account) | resource |
 | [aws_guardduty_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) | resource |
+| [aws_guardduty_organization_configuration_feature.ebs_malware_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.eks_audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.eks_runtime_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.lambda_network_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.rds_login_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.s3_data_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_iam_account_password_policy.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_account_password_policy.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_account_password_policy.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
@@ -539,7 +545,7 @@ module "landing_zone" {
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS Config settings | <pre>object({<br>    aggregator_account_ids          = optional(list(string), [])<br>    aggregator_regions              = optional(list(string), [])<br>    delivery_channel_s3_bucket_name = optional(string, null)<br>    delivery_channel_s3_key_prefix  = optional(string, null)<br>    delivery_frequency              = optional(string, "TwentyFour_Hours")<br>    rule_identifiers                = optional(list(string), [])<br>  })</pre> | <pre>{<br>  "aggregator_account_ids": [],<br>  "aggregator_regions": [],<br>  "delivery_channel_s3_bucket_name": null,<br>  "delivery_channel_s3_key_prefix": null,<br>  "delivery_frequency": "TwentyFour_Hours",<br>  "rule_identifiers": []<br>}</pre> | no |
 | <a name="input_aws_config_sns_subscription"></a> [aws\_config\_sns\_subscription](#input\_aws\_config\_sns\_subscription) | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
-| <a name="input_aws_guardduty"></a> [aws\_guardduty](#input\_aws\_guardduty) | AWS GuardDuty settings | <pre>object({<br>    enabled                      = optional(bool, true)<br>    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")<br>    datasources = object({<br>      malware_protection = optional(bool, true)<br>      kubernetes         = optional(bool, true)<br>      s3_logs            = optional(bool, true)<br>    })<br>  })</pre> | <pre>{<br>  "datasources": {<br>    "kubernetes": true,<br>    "malware_protection": true,<br>    "s3_logs": true<br>  },<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES"<br>}</pre> | no |
+| <a name="input_aws_guardduty"></a> [aws\_guardduty](#input\_aws\_guardduty) | AWS GuardDuty settings | <pre>object({<br>    enabled                       = optional(bool, true)<br>    finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")<br>    ebs_malware_protection_status = optional(bool, true)<br>    eks_addon_management_status   = optional(bool, true)<br>    eks_audit_logs_status         = optional(bool, true)<br>    eks_runtime_monitoring_status = optional(bool, true)<br>    lambda_network_logs_status    = optional(bool, true)<br>    rds_login_events_status       = optional(bool, true)<br>    s3_data_events_status         = optional(bool, true)<br>  })</pre> | <pre>{<br>  "ebs_malware_protection_status": true,<br>  "eks_addon_management_status": true,<br>  "eks_audit_logs_status": true,<br>  "eks_runtime_monitoring_status": true,<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES",<br>  "lambda_network_logs_status": true,<br>  "rds_login_events_status": true,<br>  "s3_data_events_status": true<br>}</pre> | no |
 | <a name="input_aws_required_tags"></a> [aws\_required\_tags](#input\_aws\_required\_tags) | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
 | <a name="input_aws_security_hub"></a> [aws\_security\_hub](#input\_aws\_security\_hub) | AWS Security Hub settings | <pre>object({<br>    enabled                       = optional(bool, true)<br>    auto_enable_controls          = optional(bool, true)<br>    auto_enable_default_standards = optional(bool, false)<br>    control_finding_generator     = optional(string, "SECURITY_CONTROL")<br>    create_cis_metric_filters     = optional(bool, true)<br>    product_arns                  = optional(list(string), [])<br>    standards_arns                = optional(list(string), null)<br>  })</pre> | <pre>{<br>  "auto_enable_controls": true,<br>  "auto_enable_default_standards": false,<br>  "control_finding_generator": "SECURITY_CONTROL",<br>  "create_cis_metric_filters": true,<br>  "enabled": true,<br>  "product_arns": [],<br>  "standards_arns": null<br>}</pre> | no |
 | <a name="input_aws_security_hub_sns_subscription"></a> [aws\_security\_hub\_sns\_subscription](#input\_aws\_security\_hub\_sns\_subscription) | Subscription options for the LandingZone-SecurityHubFindings SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -10,8 +10,8 @@ resource "aws_guardduty_organization_configuration" "default" {
   count    = var.aws_guardduty.enabled == true ? 1 : 0
   provider = aws.audit
 
-  auto_enable = var.aws_guardduty.enabled
-  detector_id = aws_guardduty_detector.audit.id
+  auto_enable_organization_members = var.aws_guardduty.enabled ? "ALL" : "NONE"
+  detector_id                      = aws_guardduty_detector.audit.id
 
   depends_on = [aws_guardduty_organization_admin_account.audit]
 }
@@ -24,43 +24,44 @@ resource "aws_guardduty_detector" "audit" {
   tags                         = var.tags
 }
 
-resource "aws_guardduty_detector_feature" "ebs_malware_protection" {
+resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protection" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "EBS_MALWARE_PROTECTION"
-  status      = var.aws_guardduty.ebs_malware_protection_status
+  auto_enable = var.aws_guardduty.ebs_malware_protection_status == true ? "ALL" : "NONE"
 }
 
-resource "aws_guardduty_detector_feature" "eks_audit_logs" {
+resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "EKS_AUDIT_LOGS"
-  status      = var.aws_guardduty.eks_audit_logs_status
+  auto_enable = var.aws_guardduty.eks_audit_logs_status == true ? "ALL" : "NONE"
 }
 
-resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
+resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitoring" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "EKS_RUNTIME_MONITORING"
-  status      = var.aws_guardduty.eks_runtime_monitoring_status
+  auto_enable = var.aws_guardduty.eks_runtime_monitoring_status == true ? "ALL" : "NONE"
+
 
   additional_configuration {
-    name   = "EKS_ADDON_MANAGEMENT"
-    status = var.aws_guardduty.eks_addon_management_status
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = var.aws_guardduty.eks_addon_management_status == true ? "ALL" : "NONE"
   }
 }
 
-resource "aws_guardduty_detector_feature" "lambda_network_logs" {
+resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "LAMBDA_NETWORK_LOGS"
-  status      = var.aws_guardduty.lambda_network_logs_status
+  auto_enable = var.aws_guardduty.lambda_network_logs_status == true ? "ALL" : "NONE"
 }
 
-resource "aws_guardduty_detector_feature" "rds_login_events" {
+resource "aws_guardduty_organization_configuration_feature" "rds_login_events" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "RDS_LOGIN_EVENTS"
-  status      = var.aws_guardduty.rds_login_events_status
+  auto_enable = var.aws_guardduty.rds_login_events_status == true ? "ALL" : "NONE"
 }
 
-resource "aws_guardduty_detector_feature" "s3_data_events" {
+resource "aws_guardduty_organization_configuration_feature" "s3_data_events" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "S3_DATA_EVENTS"
-  status      = var.aws_guardduty.s3_data_events_status
+  auto_enable = var.aws_guardduty.s3_data_events_status == true ? "ALL" : "NONE"
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -13,26 +13,6 @@ resource "aws_guardduty_organization_configuration" "default" {
   auto_enable = var.aws_guardduty.enabled
   detector_id = aws_guardduty_detector.audit.id
 
-  datasources {
-    kubernetes {
-      audit_logs {
-        enable = var.aws_guardduty.datasources.kubernetes
-      }
-    }
-
-    malware_protection {
-      scan_ec2_instance_with_findings {
-        ebs_volumes {
-          auto_enable = var.aws_guardduty.datasources.malware_protection
-        }
-      }
-    }
-
-    s3_logs {
-      auto_enable = var.aws_guardduty.datasources.s3_logs
-    }
-  }
-
   depends_on = [aws_guardduty_organization_admin_account.audit]
 }
 
@@ -42,10 +22,45 @@ resource "aws_guardduty_detector" "audit" {
   enable                       = var.aws_guardduty.enabled
   finding_publishing_frequency = var.aws_guardduty.finding_publishing_frequency
   tags                         = var.tags
+}
 
-  datasources {
-    s3_logs {
-      enable = true
-    }
+resource "aws_guardduty_detector_feature" "ebs_malware_protection" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "EBS_MALWARE_PROTECTION"
+  status      = var.aws_guardduty.ebs_malware_protection_status
+}
+
+resource "aws_guardduty_detector_feature" "eks_audit_logs" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "EKS_AUDIT_LOGS"
+  status      = var.aws_guardduty.eks_audit_logs_status
+}
+
+resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "EKS_RUNTIME_MONITORING"
+  status      = var.aws_guardduty.eks_runtime_monitoring_status
+
+  additional_configuration {
+    name   = "EKS_ADDON_MANAGEMENT"
+    status = var.aws_guardduty.eks_addon_management_status
   }
+}
+
+resource "aws_guardduty_detector_feature" "lambda_network_logs" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "LAMBDA_NETWORK_LOGS"
+  status      = var.aws_guardduty.lambda_network_logs_status
+}
+
+resource "aws_guardduty_detector_feature" "rds_login_events" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "RDS_LOGIN_EVENTS"
+  status      = var.aws_guardduty.rds_login_events_status
+}
+
+resource "aws_guardduty_detector_feature" "s3_data_events" {
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "S3_DATA_EVENTS"
+  status      = var.aws_guardduty.s3_data_events_status
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,24 +86,24 @@ variable "aws_guardduty" {
   type = object({
     enabled                       = optional(bool, true)
     finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")
-    ebs_malware_protection_status = optional(string, "ENABLED")
-    eks_addon_management_status   = optional(string, "ENABLED")
-    eks_audit_logs_status         = optional(string, "ENABLED")
-    eks_runtime_monitoring_status = optional(string, "ENABLED")
-    lambda_network_logs_status    = optional(string, "ENABLED")
-    rds_login_events_status       = optional(string, "ENABLED")
-    s3_data_events_status         = optional(string, "ENABLED")
+    ebs_malware_protection_status = optional(bool, true)
+    eks_addon_management_status   = optional(bool, true)
+    eks_audit_logs_status         = optional(bool, true)
+    eks_runtime_monitoring_status = optional(bool, true)
+    lambda_network_logs_status    = optional(bool, true)
+    rds_login_events_status       = optional(bool, true)
+    s3_data_events_status         = optional(bool, true)
   })
   default = {
     enabled                       = true
     finding_publishing_frequency  = "FIFTEEN_MINUTES"
-    ebs_malware_protection_status = "ENABLED"
-    eks_addon_management_status   = "ENABLED"
-    eks_audit_logs_status         = "ENABLED"
-    eks_runtime_monitoring_status = "ENABLED"
-    lambda_network_logs_status    = "ENABLED"
-    rds_login_events_status       = "ENABLED"
-    s3_data_events_status         = "ENABLED"
+    ebs_malware_protection_status = true
+    eks_addon_management_status   = true
+    eks_audit_logs_status         = true
+    eks_runtime_monitoring_status = true
+    lambda_network_logs_status    = true
+    rds_login_events_status       = true
+    s3_data_events_status         = true
   }
   description = "AWS GuardDuty settings"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -84,22 +84,26 @@ variable "aws_ebs_encryption_by_default" {
 
 variable "aws_guardduty" {
   type = object({
-    enabled                      = optional(bool, true)
-    finding_publishing_frequency = optional(string, "FIFTEEN_MINUTES")
-    datasources = object({
-      malware_protection = optional(bool, true)
-      kubernetes         = optional(bool, true)
-      s3_logs            = optional(bool, true)
-    })
+    enabled                       = optional(bool, true)
+    finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")
+    ebs_malware_protection_status = optional(string, "ENABLED")
+    eks_addon_management_status   = optional(string, "ENABLED")
+    eks_audit_logs_status         = optional(string, "ENABLED")
+    eks_runtime_monitoring_status = optional(string, "ENABLED")
+    lambda_network_logs_status    = optional(string, "ENABLED")
+    rds_login_events_status       = optional(string, "ENABLED")
+    s3_data_events_status         = optional(string, "ENABLED")
   })
   default = {
-    enabled                      = true
-    finding_publishing_frequency = "FIFTEEN_MINUTES"
-    datasources = {
-      malware_protection = true
-      kubernetes         = true
-      s3_logs            = true
-    }
+    enabled                       = true
+    finding_publishing_frequency  = "FIFTEEN_MINUTES"
+    ebs_malware_protection_status = "ENABLED"
+    eks_addon_management_status   = "ENABLED"
+    eks_audit_logs_status         = "ENABLED"
+    eks_runtime_monitoring_status = "ENABLED"
+    lambda_network_logs_status    = "ENABLED"
+    rds_login_events_status       = "ENABLED"
+    s3_data_events_status         = "ENABLED"
   }
   description = "AWS GuardDuty settings"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.60.0"
+      version               = ">= 5.20.0"
       configuration_aliases = [aws.audit, aws.logging]
     }
     datadog = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.20.0"
+      version               = ">= 5.21.0"
       configuration_aliases = [aws.audit, aws.logging]
     }
     datadog = {


### PR DESCRIPTION
Add Guardduty organization features
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature 

Features:
- s3_data_events, 
- eks_audit_logs, 
- ebs_malware_protection, 
- rds_login_events,
- eks_runtime_monitoring,
- lambda_network_logs