### PR TITLE
breaking: Control Tower 3.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,11 +459,7 @@ module "landing_zone" {
 | [aws_cloudtrail.additional_auditing_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_event_rule.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_metric_filter.iam_activity_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
-| [aws_cloudwatch_log_metric_filter.iam_activity_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
 | [aws_cloudwatch_log_metric_filter.iam_activity_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
-| [aws_cloudwatch_metric_alarm.iam_activity_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.iam_activity_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.iam_activity_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_config_aggregate_authorization.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
 | [aws_config_aggregate_authorization.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
@@ -520,8 +516,6 @@ module "landing_zone" {
 | [aws_caller_identity.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_cloudwatch_log_group.cloudtrail_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
-| [aws_cloudwatch_log_group.cloudtrail_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_cloudwatch_log_group.cloudtrail_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy_document.aws_config_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/account_audit.tf
+++ b/account_audit.tf
@@ -1,36 +1,3 @@
-resource "aws_cloudwatch_log_metric_filter" "iam_activity_audit" {
-  for_each = var.monitor_iam_activity ? merge(local.iam_activity, local.cloudtrail_activity_cis_aws_foundations) : {}
-  provider = aws.audit
-
-  name           = "LandingZone-IAMActivity-${each.key}"
-  pattern        = each.value
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail_audit[0].name
-
-  metric_transformation {
-    name      = "LandingZone-IAMActivity-${each.key}"
-    namespace = "LandingZone-IAMActivity"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "iam_activity_audit" {
-  for_each = aws_cloudwatch_log_metric_filter.iam_activity_audit
-  provider = aws.audit
-
-  alarm_name                = each.value.name
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = each.value.name
-  namespace                 = each.value.metric_transformation[0].namespace
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitors IAM activity for ${each.key}"
-  alarm_actions             = [aws_sns_topic.iam_activity[0].arn]
-  insufficient_data_actions = []
-  tags                      = var.tags
-}
-
 resource "aws_iam_account_password_policy" "audit" {
   count    = var.aws_account_password_policy != null ? 1 : 0
   provider = aws.audit

--- a/account_logging.tf
+++ b/account_logging.tf
@@ -1,36 +1,3 @@
-resource "aws_cloudwatch_log_metric_filter" "iam_activity_logging" {
-  for_each = var.monitor_iam_activity ? merge(local.iam_activity, local.cloudtrail_activity_cis_aws_foundations) : {}
-  provider = aws.logging
-
-  name           = "LandingZone-IAMActivity-${each.key}"
-  pattern        = each.value
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail_logging[0].name
-
-  metric_transformation {
-    name      = "LandingZone-IAMActivity-${each.key}"
-    namespace = "LandingZone-IAMActivity"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "iam_activity_logging" {
-  for_each = aws_cloudwatch_log_metric_filter.iam_activity_logging
-  provider = aws.logging
-
-  alarm_name                = each.value.name
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = each.value.name
-  namespace                 = each.value.metric_transformation[0].namespace
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitors IAM activity for ${each.key}"
-  alarm_actions             = [aws_sns_topic.iam_activity[0].arn]
-  insufficient_data_actions = []
-  tags                      = var.tags
-}
-
 resource "aws_iam_account_password_policy" "logging" {
   count    = var.aws_account_password_policy != null ? 1 : 0
   provider = aws.logging

--- a/data.tf
+++ b/data.tf
@@ -8,20 +8,6 @@ data "aws_caller_identity" "logging" {
 
 data "aws_caller_identity" "management" {}
 
-data "aws_cloudwatch_log_group" "cloudtrail_audit" {
-  count    = var.monitor_iam_activity ? 1 : 0
-  provider = aws.audit
-
-  name = "aws-controltower/CloudTrailLogs"
-}
-
-data "aws_cloudwatch_log_group" "cloudtrail_logging" {
-  count    = var.monitor_iam_activity ? 1 : 0
-  provider = aws.logging
-
-  name = "aws-controltower/CloudTrailLogs"
-}
-
 data "aws_cloudwatch_log_group" "cloudtrail_master" {
   count = var.monitor_iam_activity ? 1 : 0
 

--- a/files/sns/iam_activity_topic_policy.json.tpl
+++ b/files/sns/iam_activity_topic_policy.json.tpl
@@ -21,7 +21,7 @@
       "Resource": "${sns_topic}",
       "Condition": {
         "StringEquals": {
-          "AWS:SourceOwner": "${audit_account_id}"
+          "AWS:SourceAccount": "${audit_account_id}"
         }
       }
     },

--- a/files/sns/iam_activity_topic_policy.json.tpl
+++ b/files/sns/iam_activity_topic_policy.json.tpl
@@ -21,17 +21,31 @@
       "Resource": "${sns_topic}",
       "Condition": {
         "StringEquals": {
-          "AWS:SourceOwner": "${account_id}"
+          "AWS:SourceOwner": "${audit_account_id}"
         }
       }
     },
     {
-      "Sid": "__services_allowed_publish",
+      "Sid": "AllowServicesToPublishFromMgmtAccount",
       "Effect": "Allow",
       "Principal": {
         "Service": ${services_allowed_publish}
       },
       "Action": "sns:Publish",
+      "Resource": "${sns_topic}",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceAccount": "${mgmt_account_id}"
+        }
+      }
+    },
+    {
+      "Sid": "AllowMgmtMasterToListSubcriptions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${mgmt_account_id}:root"
+      },
+      "Action": "sns:ListSubscriptionsByTopic",
       "Resource": "${sns_topic}"
     }
     %{ if length(security_hub_roles) > 0 ~}

--- a/files/sns/security_hub_topic_policy.json.tpl
+++ b/files/sns/security_hub_topic_policy.json.tpl
@@ -21,7 +21,7 @@
       "Resource": "${sns_topic}",
       "Condition": {
         "StringEquals": {
-          "AWS:SourceOwner": "${account_id}"
+          "AWS:SourceAccount": "${account_id}"
         }
       }
     },

--- a/iam_activity_logging.tf
+++ b/iam_activity_logging.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "sns_feedback" {
 
     condition {
       test     = "StringEquals"
-      variable = "AWS:SourceOwner"
+      variable = "AWS:SourceAccount"
       values   = [data.aws_caller_identity.audit.account_id]
     }
   }

--- a/iam_activity_logging.tf
+++ b/iam_activity_logging.tf
@@ -16,7 +16,8 @@ resource "aws_sns_topic_policy" "iam_activity" {
   arn = aws_sns_topic.iam_activity[0].arn
 
   policy = templatefile("${path.module}/files/sns/iam_activity_topic_policy.json.tpl", {
-    account_id               = data.aws_caller_identity.audit.account_id
+    audit_account_id         = data.aws_caller_identity.audit.account_id
+    mgmt_account_id          = data.aws_caller_identity.management.account_id
     services_allowed_publish = jsonencode("cloudwatch.amazonaws.com")
     sns_topic                = aws_sns_topic.iam_activity[0].arn
 


### PR DESCRIPTION
Control Tower 3.0 support, with the consolidating of the log group 'aws-controltower/CloudTrailLogs' into the management account the log metric and alarms in the audit and logging account are removed

Also this PR changes the IAM Activity SNS topic policy to fix an error and scope it down in terms of publishing rights.

This fixes https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/issues/178

Edit: Updated account baseline related to this change. See https://github.com/schubergphilis/terraform-aws-mcaf-account-baseline/pull/15.