### PR TITLE
enhancement: Enable AWS Audit Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,14 +440,15 @@ module "landing_zone" {
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_audit_manager_reports"></a> [audit\_manager\_reports](#module\_audit\_manager\_reports) | schubergphilis/mcaf-s3/aws | 0.12.1 |
 | <a name="module_aws_config_s3"></a> [aws\_config\_s3](#module\_aws\_config\_s3) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.8.0 |
 | <a name="module_aws_sso_permission_sets"></a> [aws\_sso\_permission\_sets](#module\_aws\_sso\_permission\_sets) | ./modules/permission-set | n/a |
 | <a name="module_datadog_audit"></a> [datadog\_audit](#module\_datadog\_audit) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.12 |
 | <a name="module_datadog_logging"></a> [datadog\_logging](#module\_datadog\_logging) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.12 |
 | <a name="module_datadog_master"></a> [datadog\_master](#module\_datadog\_master) | github.com/schubergphilis/terraform-aws-mcaf-datadog | v0.3.12 |
-| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
-| <a name="module_kms_key_audit"></a> [kms\_key\_audit](#module\_kms\_key\_audit) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
-| <a name="module_kms_key_logging"></a> [kms\_key\_logging](#module\_kms\_key\_logging) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.2.0 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.3.0 |
+| <a name="module_kms_key_audit"></a> [kms\_key\_audit](#module\_kms\_key\_audit) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.3.0 |
+| <a name="module_kms_key_logging"></a> [kms\_key\_logging](#module\_kms\_key\_logging) | github.com/schubergphilis/terraform-aws-mcaf-kms | v0.3.0 |
 | <a name="module_ses-root-accounts-mail-alias"></a> [ses-root-accounts-mail-alias](#module\_ses-root-accounts-mail-alias) | github.com/schubergphilis/terraform-aws-mcaf-ses | v0.1.3 |
 | <a name="module_ses-root-accounts-mail-forward"></a> [ses-root-accounts-mail-forward](#module\_ses-root-accounts-mail-forward) | github.com/schubergphilis/terraform-aws-mcaf-ses-forwarder | v0.2.5 |
 | <a name="module_tag_policy_assignment"></a> [tag\_policy\_assignment](#module\_tag\_policy\_assignment) | ./modules/tag-policy-assignment | n/a |
@@ -456,6 +457,7 @@ module "landing_zone" {
 
 | Name | Type |
 |------|------|
+| [aws_auditmanager_account_registration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/auditmanager_account_registration) | resource |
 | [aws_cloudtrail.additional_auditing_trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_event_rule.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.security_hub_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
@@ -536,6 +538,7 @@ module "landing_zone" {
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags | `map(string)` | n/a | yes |
 | <a name="input_additional_auditing_trail"></a> [additional\_auditing\_trail](#input\_additional\_auditing\_trail) | CloudTrail configuration for additional auditing trail | <pre>object({<br>    name       = string<br>    bucket     = string<br>    kms_key_id = string<br><br>    event_selector = optional(object({<br>      data_resource = optional(object({<br>        type   = string<br>        values = list(string)<br>      }))<br>      exclude_management_event_sources = optional(set(string), null)<br>      include_management_events        = optional(bool, true)<br>      read_write_type                  = optional(string, "All")<br>    }))<br>  })</pre> | `null` | no |
 | <a name="input_aws_account_password_policy"></a> [aws\_account\_password\_policy](#input\_aws\_account\_password\_policy) | AWS account password policy parameters for the audit, logging and master account | <pre>object({<br>    allow_users_to_change        = bool<br>    max_age                      = number<br>    minimum_length               = number<br>    require_lowercase_characters = bool<br>    require_numbers              = bool<br>    require_symbols              = bool<br>    require_uppercase_characters = bool<br>    reuse_prevention_history     = number<br>  })</pre> | <pre>{<br>  "allow_users_to_change": true,<br>  "max_age": 90,<br>  "minimum_length": 14,<br>  "require_lowercase_characters": true,<br>  "require_numbers": true,<br>  "require_symbols": true,<br>  "require_uppercase_characters": true,<br>  "reuse_prevention_history": 24<br>}</pre> | no |
+| <a name="input_aws_auditmanager"></a> [aws\_auditmanager](#input\_aws\_auditmanager) | AWS Audit Manager config settings | <pre>object({<br>    enabled               = bool<br>    reports_bucket_prefix = string<br>  })</pre> | <pre>{<br>  "enabled": true,<br>  "reports_bucket_prefix": "audit-manager-reports"<br>}</pre> | no |
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS Config settings | <pre>object({<br>    aggregator_account_ids          = optional(list(string), [])<br>    aggregator_regions              = optional(list(string), [])<br>    delivery_channel_s3_bucket_name = optional(string, null)<br>    delivery_channel_s3_key_prefix  = optional(string, null)<br>    delivery_frequency              = optional(string, "TwentyFour_Hours")<br>    rule_identifiers                = optional(list(string), [])<br>  })</pre> | <pre>{<br>  "aggregator_account_ids": [],<br>  "aggregator_regions": [],<br>  "delivery_channel_s3_bucket_name": null,<br>  "delivery_channel_s3_key_prefix": null,<br>  "delivery_frequency": "TwentyFour_Hours",<br>  "rule_identifiers": []<br>}</pre> | no |
 | <a name="input_aws_config_sns_subscription"></a> [aws\_config\_sns\_subscription](#input\_aws\_config\_sns\_subscription) | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |

--- a/audit_manager.tf
+++ b/audit_manager.tf
@@ -1,0 +1,37 @@
+resource "aws_auditmanager_account_registration" "default" {
+  count = var.aws_auditmanager.enabled == true ? 1 : 0
+
+  delegated_admin_account = data.aws_caller_identity.audit.account_id
+  deregister_on_destroy   = true
+  kms_key                 = module.kms_key_audit.arn
+}
+
+module "audit_manager_reports" {
+  count     = var.aws_auditmanager.enabled == true ? 1 : 0
+  providers = { aws = aws.audit }
+
+  source      = "schubergphilis/mcaf-s3/aws"
+  version     = "0.12.1"
+  name_prefix = var.aws_auditmanager.reports_bucket_prefix
+  versioning  = true
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 7
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 90
+      }
+
+      noncurrent_version_transition = {
+        noncurrent_days = 30
+        storage_class   = "ONEZONE_IA"
+      }
+    }
+  ]
+}

--- a/kms.tf
+++ b/kms.tf
@@ -1,6 +1,6 @@
 # Management Account
 module "kms_key" {
-  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
+  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.3.0"
   name                = "inception"
   description         = "KMS key used in the master account"
   enable_key_rotation = true
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "kms_key" {
 module "kms_key_audit" {
   providers = { aws = aws.audit }
 
-  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
+  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.3.0"
   name                = "audit"
   description         = "KMS key used for encrypting audit-related data"
   enable_key_rotation = true
@@ -203,7 +203,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
 module "kms_key_logging" {
   providers = { aws = aws.logging }
 
-  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
+  source              = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.3.0"
   name                = "logging"
   description         = "KMS key to use with logging account"
   enable_key_rotation = true

--- a/organizations_policy.tf
+++ b/organizations_policy.tf
@@ -2,7 +2,7 @@ locals {
   enabled_root_policies = {
     allowed_regions = {
       enable = var.aws_service_control_policies.allowed_regions != null ? true : false
-      policy = var.aws_service_control_policies.allowed_regions != null != null ? templatefile("${path.module}/files/organizations/allowed_regions.json.tpl", {
+      policy = var.aws_service_control_policies.allowed_regions != null ? templatefile("${path.module}/files/organizations/allowed_regions.json.tpl", {
         allowed    = var.aws_service_control_policies.allowed_regions != null ? var.aws_service_control_policies.allowed_regions : []
         exceptions = var.aws_service_control_policies.principal_exceptions != null ? var.aws_service_control_policies.principal_exceptions : []
       }) : null

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,18 @@ variable "aws_account_password_policy" {
   description = "AWS account password policy parameters for the audit, logging and master account"
 }
 
+variable "aws_auditmanager" {
+  type = object({
+    enabled               = bool
+    reports_bucket_prefix = string
+  })
+  default = {
+    enabled               = true
+    reports_bucket_prefix = "audit-manager-reports"
+  }
+  description = "AWS Audit Manager config settings"
+}
+
 variable "aws_config" {
   type = object({
     aggregator_account_ids          = optional(list(string), [])


### PR DESCRIPTION
**This PR** 
- Bumps MCAF KMS module to v0.3.0
- Enabled AWS Audit Manager
- Fixes a minor bug

This PR enables AWS Audit Manager on the management account with delegated admin to audit account and also uses the audit account's KMS key.

**Recommendations**
Following AWS' recommendations the service should be enabled in the Organizations management account with delegated administrator to another account, according to best practice should be used to create assessments. 

To allow the management account to configure this key an update to the KMS key policy for the audit account has been added.

**Integrations**
AWS Config is turned on by enabling AWS Config rules or deploying a conformance pack.
Security Hub is enabled by enabling security standards and the setting: `Consolidated control findings: On`

Source: https://docs.aws.amazon.com/audit-manager/latest/userguide/setup-recommendations.html