### PR TITLE
fix: global allowed region permissions for quicksight

### DIFF
--- a/files/organizations/allowed_regions.json.tpl
+++ b/files/organizations/allowed_regions.json.tpl
@@ -61,6 +61,7 @@
                 "payments:*",
                 "pricing:*",
                 "quicksight:DescribeAccountSubscription",
+                "quicksight:DescribeTemplate",
                 "resource-explorer-2:*",
                 "route53-recovery-cluster:*",
                 "route53-recovery-control-config:*",


### PR DESCRIPTION
To implement CUDOS Dashboard, quicksight:DescribeTemplate permissions are needed for us-east-1 region.
Relevant documentation to start CF stack : 
https://github.com/aws-samples/aws-cudos-framework-deployment/blob/main/cfn-templates/cid-admin-policies.yaml