### PR TITLE
fix: for passing Control.1 Security Hub control on the core-mgmt account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,9 +653,9 @@ ENHANCEMENTS
 BUG FIXES
 
 - Add `endpoint_auto_confirms` variable to the AWS Config SNS topic ([#62](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/62)) ([#64](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/64))
-- 
+-
 - Modify accountID of the AWS Config SNS topic ([#65](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/65))
-- 
+-
 
 ## v0.4.4 - 2021-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,9 +653,7 @@ ENHANCEMENTS
 BUG FIXES
 
 - Add `endpoint_auto_confirms` variable to the AWS Config SNS topic ([#62](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/62)) ([#64](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/64))
--
 - Modify accountID of the AWS Config SNS topic ([#65](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/65))
--
 
 ## v0.4.4 - 2021-01-05
 

--- a/README.md
+++ b/README.md
@@ -487,10 +487,9 @@ module "landing_zone" {
 | [aws_iam_account_password_policy.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_account_password_policy.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_account_password_policy.master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
-| [aws_iam_role.config_recorder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.sns_feedback_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy_attachment.config_recorder_config_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_service_linked_role.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_inspector2_delegated_admin_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_delegated_admin_account) | resource |
 | [aws_inspector2_enabler.audit_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler) | resource |
 | [aws_inspector2_enabler.member_accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler) | resource |

--- a/config.tf
+++ b/config.tf
@@ -39,24 +39,13 @@ resource "aws_config_aggregate_authorization" "master_to_audit" {
   tags       = var.tags
 }
 
-resource "aws_iam_role" "config_recorder" {
-  name = "LandingZone-ConfigRecorderRole"
-  path = var.path
-  tags = var.tags
-
-  assume_role_policy = templatefile("${path.module}/files/iam/service_assume_role.json.tpl", {
-    service = "config.amazonaws.com"
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "config_recorder_config_role" {
-  role       = aws_iam_role.config_recorder.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+resource "aws_iam_service_linked_role" "config" {
+  aws_service_name = "config.amazonaws.com"
 }
 
 resource "aws_config_configuration_recorder" "default" {
   name     = "default"
-  role_arn = aws_iam_role.config_recorder.arn
+  role_arn = aws_iam_service_linked_role.config.arn
 
   recording_group {
     all_supported                 = true


### PR DESCRIPTION
See: https://docs.aws.amazon.com/securityhub/latest/userguide/controls-change-log.html (change of 2024-06-10)

The Control.1 control now also checks if the AWS Config service-linked role is used. Create and use the AWSServiceRoleForConfig instead of the custom LandingZone-ConfigRecorderRole