### PR TITLE
breaking: update GuardDuty to support runtime monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,8 @@ module "landing_zone" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.26.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.54.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | > 3.0.0 |
 | <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 
@@ -431,9 +431,9 @@ module "landing_zone" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.26.0 |
-| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 5.26.0 |
-| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.54.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | >= 5.54.0 |
+| <a name="provider_aws.logging"></a> [aws.logging](#provider\_aws.logging) | >= 5.54.0 |
 | <a name="provider_mcaf"></a> [mcaf](#provider\_mcaf) | >= 0.4.2 |
 
 ## Modules
@@ -480,9 +480,9 @@ module "landing_zone" {
 | [aws_guardduty_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) | resource |
 | [aws_guardduty_organization_configuration_feature.ebs_malware_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_guardduty_organization_configuration_feature.eks_audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
-| [aws_guardduty_organization_configuration_feature.eks_runtime_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_guardduty_organization_configuration_feature.lambda_network_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_guardduty_organization_configuration_feature.rds_login_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
+| [aws_guardduty_organization_configuration_feature.runtime_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_guardduty_organization_configuration_feature.s3_data_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration_feature) | resource |
 | [aws_iam_account_password_policy.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_account_password_policy.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
@@ -546,7 +546,7 @@ module "landing_zone" {
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS Config settings | <pre>object({<br>    aggregator_account_ids          = optional(list(string), [])<br>    aggregator_regions              = optional(list(string), [])<br>    delivery_channel_s3_bucket_name = optional(string, null)<br>    delivery_channel_s3_key_prefix  = optional(string, null)<br>    delivery_frequency              = optional(string, "TwentyFour_Hours")<br>    rule_identifiers                = optional(list(string), [])<br>  })</pre> | <pre>{<br>  "aggregator_account_ids": [],<br>  "aggregator_regions": [],<br>  "delivery_channel_s3_bucket_name": null,<br>  "delivery_channel_s3_key_prefix": null,<br>  "delivery_frequency": "TwentyFour_Hours",<br>  "rule_identifiers": []<br>}</pre> | no |
 | <a name="input_aws_config_sns_subscription"></a> [aws\_config\_sns\_subscription](#input\_aws\_config\_sns\_subscription) | Subscription options for the aws-controltower-AggregateSecurityNotifications (AWS Config) SNS topic | <pre>map(object({<br>    endpoint = string<br>    protocol = string<br>  }))</pre> | `{}` | no |
 | <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
-| <a name="input_aws_guardduty"></a> [aws\_guardduty](#input\_aws\_guardduty) | AWS GuardDuty settings | <pre>object({<br>    enabled                       = optional(bool, true)<br>    finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")<br>    ebs_malware_protection_status = optional(bool, true)<br>    eks_addon_management_status   = optional(bool, true)<br>    eks_audit_logs_status         = optional(bool, true)<br>    eks_runtime_monitoring_status = optional(bool, true)<br>    lambda_network_logs_status    = optional(bool, true)<br>    rds_login_events_status       = optional(bool, true)<br>    s3_data_events_status         = optional(bool, true)<br>  })</pre> | <pre>{<br>  "ebs_malware_protection_status": true,<br>  "eks_addon_management_status": true,<br>  "eks_audit_logs_status": true,<br>  "eks_runtime_monitoring_status": true,<br>  "enabled": true,<br>  "finding_publishing_frequency": "FIFTEEN_MINUTES",<br>  "lambda_network_logs_status": true,<br>  "rds_login_events_status": true,<br>  "s3_data_events_status": true<br>}</pre> | no |
+| <a name="input_aws_guardduty"></a> [aws\_guardduty](#input\_aws\_guardduty) | AWS GuardDuty settings | <pre>object({<br>    enabled                       = optional(bool, true)<br>    finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")<br>    ebs_malware_protection_status = optional(bool, true)<br>    eks_audit_logs_status         = optional(bool, true)<br>    lambda_network_logs_status    = optional(bool, true)<br>    rds_login_events_status       = optional(bool, true)<br>    s3_data_events_status         = optional(bool, true)<br>    runtime_monitoring_status = optional(object({<br>      enabled                             = optional(bool, true)<br>      eks_addon_management_status         = optional(bool, true)<br>      ecs_fargate_agent_management_status = optional(bool, true)<br>      ec2_agent_management_status         = optional(bool, true)<br>    }), {})<br>  })</pre> | `{}` | no |
 | <a name="input_aws_inspector"></a> [aws\_inspector](#input\_aws\_inspector) | AWS Inspector settings, at least one of the scan options must be enabled | <pre>object({<br>    enabled                 = optional(bool, false)<br>    enable_scan_ec2         = optional(bool, true)<br>    enable_scan_ecr         = optional(bool, true)<br>    enable_scan_lambda      = optional(bool, true)<br>    enable_scan_lambda_code = optional(bool, true)<br>    resource_create_timeout = optional(string, "15m")<br>  })</pre> | <pre>{<br>  "enable_scan_ec2": true,<br>  "enable_scan_ecr": true,<br>  "enable_scan_lambda": true,<br>  "enable_scan_lambda_code": true,<br>  "enabled": false,<br>  "resource_create_timeout": "15m"<br>}</pre> | no |
 | <a name="input_aws_required_tags"></a> [aws\_required\_tags](#input\_aws\_required\_tags) | AWS Required tags settings | <pre>map(list(object({<br>    name         = string<br>    values       = optional(list(string))<br>    enforced_for = optional(list(string))<br>  })))</pre> | `null` | no |
 | <a name="input_aws_security_hub"></a> [aws\_security\_hub](#input\_aws\_security\_hub) | AWS Security Hub settings | <pre>object({<br>    enabled                       = optional(bool, true)<br>    auto_enable_controls          = optional(bool, true)<br>    auto_enable_default_standards = optional(bool, false)<br>    control_finding_generator     = optional(string, "SECURITY_CONTROL")<br>    create_cis_metric_filters     = optional(bool, true)<br>    product_arns                  = optional(list(string), [])<br>    standards_arns                = optional(list(string), null)<br>  })</pre> | <pre>{<br>  "auto_enable_controls": true,<br>  "auto_enable_default_standards": false,<br>  "control_finding_generator": "SECURITY_CONTROL",<br>  "create_cis_metric_filters": true,<br>  "enabled": true,<br>  "product_arns": [],<br>  "standards_arns": null<br>}</pre> | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,51 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v4.0.0
+
+### Behaviour
+
+Using the default `aws_guardduty` values:
+* `EKS_RUNTIME_MONITORING` gets removed from the state (but not disabled)
+* `RUNTIME_MONITORING` is enabled including `ECS_FARGATE_AGENT_MANAGEMENT`, `EC2_AGENT_MANAGEMENT`, and `EKS_ADDON_MANAGEMENT`.
+
+* You need to disable `EKS_RUNTIME_MONITORING` yourself after upgrading. The commands to do so are described [in the PR](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/210).
+
+### Variables
+
+The following variables have been replaced:
+* `aws_guardduty.eks_runtime_monitoring_status` -> `aws_guardduty.runtime_monitoring_status.enabled`
+* `aws_guardduty.eks_addon_management_status` -> `aws_guardduty.runtime_monitoring_status.eks_addon_management_status`
+
+The following variables have been introduced:
+* `aws_guardduty.runtime_monitoring_status.ecs_fargate_agent_management_status`
+* `aws_guardduty.runtime_monitoring_status.ec2_agent_management_status`
+
+## Upgrading to v3.0.0
+
+### Behaviour
+
+This version add Control Tower 3.x support. Upgrade to Control Tower 3.x before upgrading to this version.
+
+## Upgrading to v2.0.0
+
+### Behaviour
+
+This version sets the minimum required aws provider version from v4 to v5.
+
+### Variables
+
+The following variables have been replaced:
+* `aws_guardduty.datasources.malware_protection` -> `aws_guardduty.ebs_malware_protection_status`
+* `aws_guardduty.datasources.kubernetes` -> `aws_guardduty.eks_audit_logs_status`
+* `aws_guardduty.datasources.s3_logs` -> `aws_guardduty.s3_data_events_status`
+
+The following variables have been introduced:
+* `aws_guardduty.eks_addon_management_status`
+* `aws_guardduty.eks_runtime_monitoring_status`
+* `aws_guardduty.lambda_network_logs_status`
+* `aws_guardduty.rds_login_events_status`
+
 ## Upgrading to v1.0.0
 
 ### Behaviour

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40.0"
+      version = ">= 5.54.0"
     }
     datadog = {
       source  = "datadog/datadog"
@@ -13,5 +13,5 @@ terraform {
       version = ">= 0.4.2"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.6"
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -6,6 +6,14 @@ resource "aws_guardduty_organization_admin_account" "audit" {
 }
 
 // AWS GuardDuty - Audit account configuration
+resource "aws_guardduty_detector" "audit" {
+  provider = aws.audit
+
+  enable                       = var.aws_guardduty.enabled
+  finding_publishing_frequency = var.aws_guardduty.finding_publishing_frequency
+  tags                         = var.tags
+}
+
 resource "aws_guardduty_organization_configuration" "default" {
   count    = var.aws_guardduty.enabled == true ? 1 : 0
   provider = aws.audit
@@ -14,14 +22,6 @@ resource "aws_guardduty_organization_configuration" "default" {
   detector_id                      = aws_guardduty_detector.audit.id
 
   depends_on = [aws_guardduty_organization_admin_account.audit]
-}
-
-resource "aws_guardduty_detector" "audit" {
-  provider = aws.audit
-
-  enable                       = var.aws_guardduty.enabled
-  finding_publishing_frequency = var.aws_guardduty.finding_publishing_frequency
-  tags                         = var.tags
 }
 
 resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protection" {
@@ -38,20 +38,6 @@ resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "EKS_AUDIT_LOGS"
   auto_enable = var.aws_guardduty.eks_audit_logs_status == true ? "ALL" : "NONE"
-}
-
-resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitoring" {
-  provider = aws.audit
-
-  detector_id = aws_guardduty_detector.audit.id
-  name        = "EKS_RUNTIME_MONITORING"
-  auto_enable = var.aws_guardduty.eks_runtime_monitoring_status == true ? "ALL" : "NONE"
-
-
-  additional_configuration {
-    name        = "EKS_ADDON_MANAGEMENT"
-    auto_enable = var.aws_guardduty.eks_addon_management_status == true ? "ALL" : "NONE"
-  }
 }
 
 resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs" {
@@ -76,4 +62,28 @@ resource "aws_guardduty_organization_configuration_feature" "s3_data_events" {
   detector_id = aws_guardduty_detector.audit.id
   name        = "S3_DATA_EVENTS"
   auto_enable = var.aws_guardduty.s3_data_events_status == true ? "ALL" : "NONE"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
+  provider = aws.audit
+
+  detector_id = aws_guardduty_detector.audit.id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = var.aws_guardduty.runtime_monitoring_status.enabled == true ? "ALL" : "NONE"
+
+
+  dynamic "additional_configuration" {
+    for_each = {
+      for name, status in {
+        "EC2_AGENT_MANAGEMENT"         = var.aws_guardduty.runtime_monitoring_status.ec2_agent_management_status
+        "ECS_FARGATE_AGENT_MANAGEMENT" = var.aws_guardduty.runtime_monitoring_status.ecs_fargate_agent_management_status
+        "EKS_ADDON_MANAGEMENT"         = var.aws_guardduty.runtime_monitoring_status.eks_addon_management_status
+      } : name => status if status == true
+    }
+
+    content {
+      name        = additional_configuration.key
+      auto_enable = "ALL"
+    }
+  }
 }

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -7,6 +7,8 @@ resource "aws_guardduty_organization_admin_account" "audit" {
 
 // AWS GuardDuty - Audit account configuration
 resource "aws_guardduty_detector" "audit" {
+  #checkov:skip=CKV_AWS_238: "Ensure that GuardDuty detector is enabled" - False positive, GuardDuty is enabled by default.
+  #checkov:skip=CKV2_AWS_3: "Ensure GuardDuty is enabled to specific org/region" - False positive, GuardDuty is enabled by default.
   provider = aws.audit
 
   enable                       = var.aws_guardduty.enabled

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -71,18 +71,29 @@ resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring"
   name        = "RUNTIME_MONITORING"
   auto_enable = var.aws_guardduty.runtime_monitoring_status.enabled == true ? "ALL" : "NONE"
 
-
   dynamic "additional_configuration" {
-    for_each = {
-      for name, status in {
-        "EC2_AGENT_MANAGEMENT"         = var.aws_guardduty.runtime_monitoring_status.ec2_agent_management_status
-        "ECS_FARGATE_AGENT_MANAGEMENT" = var.aws_guardduty.runtime_monitoring_status.ecs_fargate_agent_management_status
-        "EKS_ADDON_MANAGEMENT"         = var.aws_guardduty.runtime_monitoring_status.eks_addon_management_status
-      } : name => status if status == true
-    }
+    for_each = var.aws_guardduty.runtime_monitoring_status.ecs_fargate_agent_management_status == true ? ["ECS_FARGATE_AGENT_MANAGEMENT"] : []
 
     content {
-      name        = additional_configuration.key
+      name        = additional_configuration.value
+      auto_enable = "ALL"
+    }
+  }
+
+  dynamic "additional_configuration" {
+    for_each = var.aws_guardduty.runtime_monitoring_status.ec2_agent_management_status == true ? ["EC2_AGENT_MANAGEMENT"] : []
+
+    content {
+      name        = additional_configuration.value
+      auto_enable = "ALL"
+    }
+  }
+
+  dynamic "additional_configuration" {
+    for_each = var.aws_guardduty.runtime_monitoring_status.eks_addon_management_status == true ? ["EKS_ADDON_MANAGEMENT"] : []
+
+    content {
+      name        = additional_configuration.value
       auto_enable = "ALL"
     }
   }

--- a/ses_accounts_mail_alias.tf
+++ b/ses_accounts_mail_alias.tf
@@ -14,9 +14,10 @@ module "ses-root-accounts-mail-alias" {
 }
 
 module "ses-root-accounts-mail-forward" {
-  #checkov:skip=CKV_AWS_19: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
-  #checkov:skip=CKV_AWS_145: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
-  #checkov:skip=CKV_AWS_272: This module does not support lambda code signing at the moment
+  # checkov:skip=CKV_AWS_19: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
+  # checkov:skip=CKV_AWS_145: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
+  # checkov:skip=CKV_AWS_272: This module does not support lambda code signing at the moment
+
   count = var.ses_root_accounts_mail_forward != null ? 1 : 0
 
   source  = "schubergphilis/mcaf-ses-forwarder/aws"

--- a/ses_accounts_mail_alias.tf
+++ b/ses_accounts_mail_alias.tf
@@ -14,10 +14,9 @@ module "ses-root-accounts-mail-alias" {
 }
 
 module "ses-root-accounts-mail-forward" {
-  # checkov:skip=CKV_AWS_19: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
-  # checkov:skip=CKV_AWS_145: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
-  # checkov:skip=CKV_AWS_272: This module does not support lambda code signing at the moment
-
+  #checkov:skip=CKV_AWS_19: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
+  #checkov:skip=CKV_AWS_145: False positive: https://github.com/bridgecrewio/checkov/issues/3847. The S3 bucket created by this module is encrypted with KMS.
+  #checkov:skip=CKV_AWS_272: This module does not support lambda code signing at the moment
   count = var.ses_root_accounts_mail_forward != null ? 1 : 0
 
   source  = "schubergphilis/mcaf-ses-forwarder/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -99,24 +99,18 @@ variable "aws_guardduty" {
     enabled                       = optional(bool, true)
     finding_publishing_frequency  = optional(string, "FIFTEEN_MINUTES")
     ebs_malware_protection_status = optional(bool, true)
-    eks_addon_management_status   = optional(bool, true)
     eks_audit_logs_status         = optional(bool, true)
-    eks_runtime_monitoring_status = optional(bool, true)
     lambda_network_logs_status    = optional(bool, true)
     rds_login_events_status       = optional(bool, true)
     s3_data_events_status         = optional(bool, true)
+    runtime_monitoring_status = optional(object({
+      enabled                             = optional(bool, true)
+      eks_addon_management_status         = optional(bool, true)
+      ecs_fargate_agent_management_status = optional(bool, true)
+      ec2_agent_management_status         = optional(bool, true)
+    }), {})
   })
-  default = {
-    enabled                       = true
-    finding_publishing_frequency  = "FIFTEEN_MINUTES"
-    ebs_malware_protection_status = true
-    eks_addon_management_status   = true
-    eks_audit_logs_status         = true
-    eks_runtime_monitoring_status = true
-    lambda_network_logs_status    = true
-    rds_login_events_status       = true
-    s3_data_events_status         = true
-  }
+  default     = {}
   description = "AWS GuardDuty settings"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.26.0"
+      version               = ">= 5.54.0"
       configuration_aliases = [aws.audit, aws.logging]
     }
     datadog = {
@@ -14,5 +14,5 @@ terraform {
       version = ">= 0.4.2"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.6"
 }


### PR DESCRIPTION
> [!NOTE]
> GuardDuty has consolidated EKS Runtime Monitoring into Runtime Monitoring. EKS Runtime Monitoring has been deprecated. 
> GuardDuty recommends [Checking EKS Runtime Monitoring configuration status](https://docs.aws.amazon.com/guardduty/latest/ug/checking-eks-runtime-monitoring-enable-status.html) and to [migrating from EKS Runtime Monitoring to Runtime Monitoring](https://docs.aws.amazon.com/guardduty/latest/ug/migrating-from-eksrunmon-to-runtime-monitoring.html).
> ![eks-runtime-monitoring-deprecation](https://github.com/user-attachments/assets/0755bc2b-10f9-4059-85af-b288b8456dcd)

This PR refactors `EKS_RUNTIME_MONITORING` to `RUNTIME_MONITORING` and additionally enables ECS and EC2 as well. Runtime monitoring for EKS can now be controlled via the `var.guardduty.runtime_monitoring_status.eks_addon_management_status` variable.

> [!WARNING]
> **Check the diagram! If you currently have EKS Runtime Monitoring enabled, you need to perform MANUAL steps after you have migrated to this version.** 

# What steps do I need to take?

![Guardduty(2)](https://github.com/user-attachments/assets/c3a00d31-96b2-4b4c-8b07-2b3a8f7bdd61)


# EKS Runtime Monitoring to Runtime Monitoring migration
Check out the steps in the [upgrading file](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/blob/master/UPGRADING.md).