### PR TITLE
feature: Add Organization Policy to deny all regions except for the allowed_regions and us-east-1

### DIFF
--- a/files/organizations/allowed_regions.json.tpl
+++ b/files/organizations/allowed_regions.json.tpl
@@ -109,12 +109,24 @@
             "Condition": {
                 "StringNotEquals": {
                     "aws:RequestedRegion": ${jsonencode(allowed)}
-                }
-                %{ if length(exceptions) > 0 ~}
-                ,"ArnNotLike": {
+                },
+                "ArnNotLike": {
                     "aws:PrincipalARN": ${jsonencode(exceptions)}
                 }
-                %{ endif ~}
+            }
+        },
+        {
+            "Sid": "DenyAllOtherRegions",
+            "Effect": "Deny",
+            "Action": "*",
+            "Resource": "*",
+            "Condition": {
+                "StringNotEquals": {
+                    "aws:RequestedRegion":  ${jsonencode(allowed_plus_us_east)}
+                },
+                "ArnNotLike": {
+                    "aws:PrincipalARN": ${jsonencode(exceptions)}
+                }
             }
         }
     ]

--- a/modules/permission-set/README.md
+++ b/modules/permission-set/README.md
@@ -146,3 +146,50 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssoadmin_account_assignment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
+| [aws_ssoadmin_managed_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
+| [aws_ssoadmin_permission_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
+| [aws_ssoadmin_permission_set_inline_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
+| [aws_identitystore_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
+| [aws_ssoadmin_instances.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+| [aws_ssoadmin_permission_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_permission_set) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Name of the permission set | `string` | n/a | yes |
+| <a name="input_assignments"></a> [assignments](#input\_assignments) | List of account names and IDs and Identity Center groups to assign to the permission set | <pre>list(object({<br/>    account_id   = string<br/>    account_name = string<br/>    sso_groups   = list(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Set to false to only manage assignments when the permission set already exists | `bool` | `true` | no |
+| <a name="input_inline_policy"></a> [inline\_policy](#input\_inline\_policy) | The IAM inline policy to attach to a permission set | `string` | `null` | no |
+| <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | List of IAM managed policy ARNs to be attached to the permission set | `list(string)` | `[]` | no |
+| <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | A list of external resources the module depends\_on | `any` | `[]` | no |
+| <a name="input_session_duration"></a> [session\_duration](#input\_session\_duration) | The length of time that the application user sessions are valid in the ISO-8601 standard | `string` | `"PT4H"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/tag-policy-assignment/README.md
+++ b/modules/tag-policy-assignment/README.md
@@ -27,3 +27,42 @@
 No output.
 
 <!--- END_TF_DOCS --->
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_organizations_policy.required_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
+| [aws_organizations_policy_attachment.required_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_ou_tags"></a> [aws\_ou\_tags](#input\_aws\_ou\_tags) | Map of AWS OU names and their tag policies | <pre>map(object({<br/>    values       = optional(list(string))<br/>    enforced_for = optional(list(string))<br/>  }))</pre> | n/a | yes |
+| <a name="input_ou_path"></a> [ou\_path](#input\_ou\_path) | Path of the organizational unit (OU) | `string` | n/a | yes |
+| <a name="input_target_id"></a> [target\_id](#input\_target\_id) | The unique identifier (ID) organizational unit (OU) that you want to attach the policy to. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of AWS resource tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/organizations_policy.tf
+++ b/organizations_policy.tf
@@ -5,7 +5,7 @@ locals {
       policy = var.regions.allowed_regions != null ? templatefile("${path.module}/files/organizations/allowed_regions.json.tpl", {
         allowed              = var.regions.allowed_regions != null ? var.regions.allowed_regions : []
         exceptions           = local.aws_service_control_policies_principal_exceptions
-        allowed_plus_us_east = var.regions.allowed_regions != null ? distinct(concat(var.regions.allowed_regions, "us-east-1")) : []
+        allowed_plus_us_east = var.regions.allowed_regions != null ? distinct(concat(var.regions.allowed_regions, ["us-east-1"])) : []
       }) : null
     }
     cloudtrail_log_stream = {

--- a/organizations_policy.tf
+++ b/organizations_policy.tf
@@ -3,8 +3,9 @@ locals {
     allowed_regions = {
       enable = var.regions.allowed_regions != null ? true : false
       policy = var.regions.allowed_regions != null ? templatefile("${path.module}/files/organizations/allowed_regions.json.tpl", {
-        allowed    = var.regions.allowed_regions != null ? var.regions.allowed_regions : []
-        exceptions = local.aws_service_control_policies_principal_exceptions
+        allowed              = var.regions.allowed_regions != null ? var.regions.allowed_regions : []
+        exceptions           = local.aws_service_control_policies_principal_exceptions
+        allowed_plus_us_east = var.regions.allowed_regions != null ? distinct(concat(var.regions.allowed_regions, "us-east-1")) : []
       }) : null
     }
     cloudtrail_log_stream = {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
Add an Organization Policy to deny all regions except for the allowed_regions and `us-east-1` regions.

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->
Current setup allows all services defined in `DenyAllRegionsOutsideAllowedList` to be used in regions that cannot be disabled. `us-east-1` is added to ensure global services remain untouched.

