### PR TITLE
bug: add ssm:GetPar* to the global services actions to be able to deploy global services using AWS CDK

### DIFF
--- a/organizations_policy_allowed_regions.tf
+++ b/organizations_policy_allowed_regions.tf
@@ -89,6 +89,7 @@ locals {
     "savingsplans:*",
     "servicequotas:*",
     "shield:*",
+    "ssm:GetPar*",
     "sso:*",
     "sts:*",
     "support:*",


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
* add ssm:GetPar* to the global services actions to be able to deploy global services using AWS CDK. If AWS CDK cannot read SSM parameters in us-east-1 then it's not able to deploy global services. 
* this is in line with some other service actions in our scp like `lightsail:Get*`.
