### PR TITLE
bug: add s3:ListBuckets to the global services actions

### DIFF
--- a/organizations_policy_allowed_regions.tf
+++ b/organizations_policy_allowed_regions.tf
@@ -82,6 +82,7 @@ locals {
     "s3:GetStorageLensConfiguration",
     "s3:GetStorageLensDashboard",
     "s3:ListAllMyBuckets",
+    "s3:ListBuckets",
     "s3:ListMultiRegionAccessPoints",
     "s3:ListStorageLensConfigurations",
     "s3:PutAccountPublicAccessBlock",


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
We already allow the `s3:ListAllMyBuckets` in us-east-1, but some global services use `s3:ListBuckets` (https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html). Add this service action as well to prevent issues with global services. 
