### PR TITLE
fix: add validation to the region variable to prevent faulty configuration

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -34,5 +34,6 @@ locals {
   security_hub_has_cis_aws_foundations_enabled = length(regexall(
     "cis-aws-foundations-benchmark/v", join(",", local.security_hub_standards_arns)
   )) > 0 ? true : false
+
   all_organisation_regions = toset(distinct(concat([var.regions.home_region], var.regions.linked_regions, var.regions.allowed_regions, [data.aws_region.current.name])))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -310,6 +310,14 @@ variable "regions" {
     condition     = length(var.regions.linked_regions) > 0
     error_message = "The 'linked_regions' list must include at least one region. By default, 'us-east-1' is specified to ensure the tracking of global resources. Please specify at least one region if overriding the default."
   }
+
+  validation {
+    condition = alltrue([
+      for region in keys(var.regions.additional_allowed_service_actions_per_region) :
+      !contains(var.regions.allowed_regions, region)
+    ])
+    error_message = "You cannot specify 'additional_allowed_service_actions_per_region' for a region already in 'allowed_regions'. The 'allowed_regions' list already grants full service-action access there, so any per-region overrides must only target regions not listed in 'allowed_regions'."
+  }
 }
 
 variable "path" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Add validation to prevent faulty configuration of the `regions` variable: 
- You cannot specify 'additional_allowed_service_actions_per_region' for a region already in 'allowed_regions'. The 'allowed_regions' list already grants full service-action access there, so any per-region overrides must only target regions not listed in 'allowed_regions'.