### PR TITLE
feature: add required control tower permissions to the management account kms key

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "aws_config_s3_bucket_arn" {
   value       = module.aws_config_s3.arn
 }
 
+output "aws_config_s3_bucket_name" {
+  description = "Name of the AWS Config S3 bucket in the logging account"
+  value       = module.aws_config_s3.name
+}
+
 output "aws_config_iam_service_linked_role_arn" {
   description = "IAM Service Linked Role ARN for AWS Config in the management account"
   value       = aws_iam_service_linked_role.config.arn


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
In our deployment guide we describe using the management account KMS key for Control Tower deployment, but users had to manually add certain key policies for it to function. This PR automatically injects the required policy statements for Control Tower, CloudTrail log group encryption (with an ArnLike condition), CloudWatch, SNS. 

As a result, the KMS key now works for Control Tower out of the box.