### PR TITLE
bug: Adding validation and merge logic for kms ControlTower statement

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -1,3 +1,73 @@
+locals {
+
+  # Audit Account
+  decoded_policy_documents_audit = [for policy_json in var.kms_key_policy_audit : jsondecode(policy_json)]
+  all_statements_audit = flatten([
+    for policy in local.decoded_policy_documents_audit : try(coalesce(policy.Statement, policy.statement), [])
+  ])
+  user_sids_audit = [for statement in local.all_statements_audit : try(coalesce(statement.Sid, statement.sid),"")]
+  has_admin_control_tower_sid_audit = contains(local.user_sids_audit, "Administrative permissions for pipeline")
+  # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
+  user_admin_statement_audit = local.has_admin_control_tower_sid_audit ? one([
+    for s in local.all_statements_audit :
+    {
+      actions = try(coalesce(s.Actions, s.actions), [])
+    }
+    if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
+  ]) : []
+  default_admin_control_tower_actions_audit = [
+    "kms:Create*",
+    "kms:Describe*",
+    "kms:Enable*",
+    "kms:GenerateDataKey*",
+    "kms:Get*",
+    "kms:List*",
+    "kms:Put*",
+    "kms:Revoke*",
+    "kms:TagResource",
+    "kms:UntagResource",
+    "kms:Update*"
+  ]
+  merged_admin_control_tower_actions_audit = distinct(concat(
+    local.default_admin_control_tower_actions_audit,
+    try(local.user_admin_statement_audit.actions, [])
+  ))
+
+  # Logging Account
+  decoded_policy_documents_logging = [for policy_json in var.kms_key_policy_logging : jsondecode(policy_json)]
+  all_statements_logging = flatten([
+    for policy in local.decoded_policy_documents_logging : try(coalesce(policy.Statement, policy.statement), [])
+  ])
+  user_sids_logging = [for statement in local.all_statements_logging : try(coalesce(statement.Sid, statement.sid),"")]
+  has_admin_control_tower_sid_logging = contains(local.user_sids_logging, "Administrative permissions for pipeline")
+  # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
+  user_admin_statement_logging = local.has_admin_control_tower_sid_logging ? one([
+    for s in local.all_statements_logging :
+    {
+      actions = try(coalesce(s.Actions, s.actions), [])
+    }
+    if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
+  ]) : []
+  default_admin_control_tower_actions_logging = [
+    "kms:Create*",
+    "kms:Describe*",
+    "kms:Enable*",
+    "kms:Get*",
+    "kms:List*",
+    "kms:Put*",
+    "kms:Revoke*",
+    "kms:TagResource",
+    "kms:UntagResource",
+    "kms:Update*",
+    "kms:GenerateDataKey*"
+  ]
+  merged_admin_control_tower_actions_logging = distinct(concat(
+    local.default_admin_control_tower_actions_logging,
+    try(local.user_admin_statement_logging.actions, [])
+  ))
+  
+}
+
 # Management Account
 module "kms_key" {
   source  = "schubergphilis/mcaf-kms/aws"
@@ -170,33 +240,25 @@ data "aws_iam_policy_document" "kms_key_audit" {
     }
   }
 
-  statement {
-    sid       = "Administrative permissions for pipeline"
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+  # Add merged 'Administrative permissions for pipeline' if user includes that SID
+  dynamic "statement" {
+    for_each = local.has_admin_control_tower_sid_audit ? [1] : []
 
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:GenerateDataKey*",
-      "kms:Get*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Revoke*",
-      "kms:TagResource",
-      "kms:UntagResource",
-      "kms:Update*"
-    ]
+    content {
+      sid       = "Administrative permissions for pipeline"
+      effect    = "Allow"
+      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.audit.account_id}:role/AWSControlTowerExecution"
-      ]
+      actions = local.merged_admin_control_tower_actions_audit
+
+      principals {
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_caller_identity.audit.account_id}:AWSControlTowerExecution"
+        ]
+      }
     }
   }
-
   statement {
     sid       = "List KMS keys permissions for all IAM users"
     effect    = "Allow"
@@ -353,32 +415,25 @@ data "aws_iam_policy_document" "kms_key_logging" {
     }
   }
 
-  statement {
-    sid       = "Administrative permissions for pipeline"
-    effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+  # Add merged 'Administrative permissions for pipeline' if user includes that SID
+  dynamic "statement" {
+    for_each = local.has_admin_control_tower_sid_logging ? [1] : []
 
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:Get*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Revoke*",
-      "kms:TagResource",
-      "kms:UntagResource",
-      "kms:Update*"
-    ]
+    content {
+      sid       = "Administrative permissions for pipeline"
+      effect    = "Allow"
+      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.logging.account_id}:role/AWSControlTowerExecution"
-      ]
+      actions = local.merged_admin_control_tower_actions_logging
+
+      principals {
+        type = "AWS"
+        identifiers = [
+          "arn:aws:iam::${data.aws_caller_identity.logging.account_id}:AWSControlTowerExecution"
+        ]
+      }
     }
   }
-
   statement {
     sid       = "List KMS keys permissions for all IAM users"
     effect    = "Allow"

--- a/kms.tf
+++ b/kms.tf
@@ -8,11 +8,11 @@ locals {
   user_sids_audit = [for statement in local.all_statements_audit : try(coalesce(statement.Sid, statement.sid),"")]
   has_admin_control_tower_sid_audit = contains(local.user_sids_audit, "Administrative permissions for pipeline")
   # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
-  user_admin_statement_audit = local.has_admin_control_tower_sid_audit ? one([
-    for s in local.all_statements_audit :
-    {
-      actions = try(coalesce(s.Actions, s.actions), [])
-    }
+  user_admin_statement_audit = local.has_admin_control_tower_sid_audit && length([
+    for s in local.all_statements_audit : s
+    if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
+  ]) > 0 ? one([
+    for s in local.all_statements_audit : try(coalesce(s.Action, s.action), [])
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
   ]) : []
   default_admin_control_tower_actions_audit = [
@@ -41,11 +41,11 @@ locals {
   user_sids_logging = [for statement in local.all_statements_logging : try(coalesce(statement.Sid, statement.sid),"")]
   has_admin_control_tower_sid_logging = contains(local.user_sids_logging, "Administrative permissions for pipeline")
   # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
-  user_admin_statement_logging = local.has_admin_control_tower_sid_logging ? one([
-    for s in local.all_statements_logging :
-    {
-      actions = try(coalesce(s.Actions, s.actions), [])
-    }
+  user_admin_statement_logging = local.has_admin_control_tower_sid_logging && length([
+    for s in local.all_statements_logging : s
+    if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
+  ]) > 0 ? one([
+    for s in local.all_statements_logging : try(coalesce(s.Action, s.action), [])
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
   ]) : []
   default_admin_control_tower_actions_logging = [

--- a/kms.tf
+++ b/kms.tf
@@ -5,13 +5,13 @@ locals {
   all_statements_audit = flatten([
     for policy in local.decoded_policy_documents_audit : try(coalesce(policy.Statement, policy.statement), [])
   ])
-  user_sids_audit = [for statement in local.all_statements_audit : try(coalesce(statement.Sid, statement.sid),"")]
+  user_sids_audit                   = [for statement in local.all_statements_audit : try(coalesce(statement.Sid, statement.sid), "")]
   has_admin_control_tower_sid_audit = contains(local.user_sids_audit, "Administrative permissions for pipeline")
   # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
   user_admin_statement_audit = local.has_admin_control_tower_sid_audit && length([
     for s in local.all_statements_audit : s
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
-  ]) > 0 ? one([
+    ]) > 0 ? one([
     for s in local.all_statements_audit : try(coalesce(s.Action, s.action), [])
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
   ]) : []
@@ -38,13 +38,13 @@ locals {
   all_statements_logging = flatten([
     for policy in local.decoded_policy_documents_logging : try(coalesce(policy.Statement, policy.statement), [])
   ])
-  user_sids_logging = [for statement in local.all_statements_logging : try(coalesce(statement.Sid, statement.sid),"")]
+  user_sids_logging                   = [for statement in local.all_statements_logging : try(coalesce(statement.Sid, statement.sid), "")]
   has_admin_control_tower_sid_logging = contains(local.user_sids_logging, "Administrative permissions for pipeline")
   # Extract user-supplied statement matching the SID 'Administrative permissions for pipeline'
   user_admin_statement_logging = local.has_admin_control_tower_sid_logging && length([
     for s in local.all_statements_logging : s
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
-  ]) > 0 ? one([
+    ]) > 0 ? one([
     for s in local.all_statements_logging : try(coalesce(s.Action, s.action), [])
     if try(coalesce(s.Sid, s.sid), "") == "Administrative permissions for pipeline"
   ]) : []
@@ -65,7 +65,7 @@ locals {
     local.default_admin_control_tower_actions_logging,
     try(local.user_admin_statement_logging.actions, [])
   ))
-  
+
 }
 
 # Management Account


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
The current module includes a hardcoded policy statement with Sid = "Administrative permissions for pipeline" that grants a predefined set of actions to the AWSControlTowerExecution role for audit and logging accounts.

However, when a user calls this module and passes a custom policy document via the kms_key_policy_audit and/or kms_key_policy_logging variables that include the same SID (Administrative permissions for pipeline) with additional or different actions, the module overwrites that statement instead of merging or respecting the user's inputs.

This limits flexibility and breaks the principle of composability, especially when multiple consumers want to reuse this module and customize permissions without modifying the module source code.

**:rocket: Motivation**
When using the variable (kms_key_policy_audit and/or kms_key_policy_logging) to pass in additional statements or actions, but if you add a statement with the same SID (Administrative permissions for pipeline) to add new actions, the module does not merge passed actions with the existing default statement. This results in the additional actions not being included in the intended statement.

**:pencil: Additional Information**
Update the module logic to:

Parse and inspect user-passed policy documents (kms_key_policy_audit and kms_key_policy_logging (list of JSON strings)).

Detect if the user has provided a statement with the SID "Administrative permissions for pipeline".

If so, merge the Action field from the user’s statement with the module’s default actions.

If the SID (Administrative permissions for pipeline) is not provided by the user, fallback to the default policy as defined in the module.

This change ensures that users can extend the permissions granted by the module for the specific SID (Administrative permissions for pipeline) without altering the module or breaking compatibility.
