### PR TITLE
fix: deprecated data.aws_region.current.name

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -20,7 +20,7 @@ locals {
 
   aws_config_s3_name = coalesce(
     var.aws_config.delivery_channel_s3_bucket_name,
-    "aws-config-configuration-history-${var.control_tower_account_ids.logging}-${data.aws_region.current.name}"
+    "aws-config-configuration-history-${var.control_tower_account_ids.logging}-${data.aws_region.current.region}"
   )
 }
 
@@ -83,7 +83,7 @@ resource "aws_sns_topic_subscription" "aws_config" {
   endpoint               = each.value.endpoint
   endpoint_auto_confirms = length(regexall("http", each.value.protocol)) > 0
   protocol               = each.value.protocol
-  topic_arn              = "arn:aws:sns:${data.aws_region.current.name}:${var.control_tower_account_ids.audit}:aws-controltower-AggregateSecurityNotifications"
+  topic_arn              = "arn:aws:sns:${data.aws_region.current.region}:${var.control_tower_account_ids.audit}:aws-controltower-AggregateSecurityNotifications"
 }
 
 // AWS Config - Logging account configuration

--- a/kms.tf
+++ b/kms.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "kms_key" {
     sid       = "Base Permissions"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
     principals {
       type = "AWS"
@@ -37,21 +37,21 @@ data "aws_iam_policy_document" "kms_key" {
       "kms:ReEncrypt*"
     ]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:aws-controltower/CloudTrailLogs:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:aws-controltower/CloudTrailLogs:*"
       ]
     }
 
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com"
+        "logs.${data.aws_region.current.region}.amazonaws.com"
       ]
     }
   }
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "kms_key" {
   statement {
     sid       = "Allow Control Tower dependencies CloudWatch, CloudTrail, Config & SNS Decrypt"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "kms_key" {
     content {
       sid       = "Allow SES Decrypt"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
       actions = [
         "kms:Decrypt",
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "kms_key" {
     content {
       sid       = "Allow EmailForwarder CloudWatch Log Group"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
       actions = [
         "kms:Decrypt",
@@ -119,14 +119,14 @@ data "aws_iam_policy_document" "kms_key" {
         variable = "kms:EncryptionContext:aws:logs:arn"
 
         values = [
-          "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:log-group:/aws/lambda/EmailForwarder"
+          "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:log-group:/aws/lambda/EmailForwarder"
         ]
       }
 
       principals {
         type = "Service"
         identifiers = [
-          "logs.${data.aws_region.current.name}.amazonaws.com"
+          "logs.${data.aws_region.current.region}.amazonaws.com"
         ]
       }
     }
@@ -154,7 +154,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
     sid       = "Full permissions for the root user only"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     condition {
       test     = "StringEquals"
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
   statement {
     sid       = "Administrative permissions for pipeline"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     actions = [
       "kms:Create*",
@@ -200,7 +200,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
   statement {
     sid       = "List KMS keys permissions for all IAM users"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     actions = [
       "kms:Describe*",
@@ -219,7 +219,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
   statement {
     sid       = "Allow CloudWatch Decrypt"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",
@@ -238,7 +238,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
   statement {
     sid       = "Allow SNS Decrypt"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",
@@ -259,7 +259,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
     content {
       sid       = "Allow Audit Manager from management to describe and grant"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.audit.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.audit.account_id}:key/*"]
 
       actions = [
         "kms:CreateGrant",
@@ -289,7 +289,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
     content {
       sid       = "Encrypt and Decrypt permissions for S3"
       effect    = "Allow"
-      resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.management.account_id}:key/*"]
+      resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.management.account_id}:key/*"]
 
       actions = [
         "kms:Encrypt",
@@ -309,7 +309,7 @@ data "aws_iam_policy_document" "kms_key_audit" {
         test     = "StringLike"
         variable = "kms:ViaService"
         values = [
-          "s3.${data.aws_region.current.name}.amazonaws.com",
+          "s3.${data.aws_region.current.region}.amazonaws.com",
         ]
       }
     }
@@ -337,7 +337,7 @@ data "aws_iam_policy_document" "kms_key_logging" {
     sid       = "Full permissions for the root user only"
     actions   = ["kms:*"]
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     condition {
       test     = "StringEquals"
@@ -356,7 +356,7 @@ data "aws_iam_policy_document" "kms_key_logging" {
   statement {
     sid       = "Administrative permissions for pipeline"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     actions = [
       "kms:Create*",
@@ -382,7 +382,7 @@ data "aws_iam_policy_document" "kms_key_logging" {
   statement {
     sid       = "List KMS keys permissions for all IAM users"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     actions = [
       "kms:Describe*",
@@ -401,7 +401,7 @@ data "aws_iam_policy_document" "kms_key_logging" {
   statement {
     sid       = "KMS permissions for AWS logs service"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     actions = [
       "kms:Encrypt",
@@ -413,14 +413,14 @@ data "aws_iam_policy_document" "kms_key_logging" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
   }
 
   statement {
     sid       = "AllowAWSConfigToEncryptDecryptLogs"
     effect    = "Allow"
-    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.logging.account_id}:key/*"]
+    resources = ["arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.logging.account_id}:key/*"]
 
     actions = [
       "kms:Decrypt",

--- a/locals.tf
+++ b/locals.tf
@@ -24,9 +24,9 @@ locals {
   aws_service_control_policies_principal_exceptions = distinct(concat(var.aws_service_control_policies.principal_exceptions, ["arn:aws:iam::*:role/AWSControlTowerExecution"]))
 
   security_hub_standards_arns_default = [
-    "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0",
-    "arn:aws:securityhub:${data.aws_region.current.name}::standards/cis-aws-foundations-benchmark/v/1.4.0",
-    "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
+    "arn:aws:securityhub:${data.aws_region.current.region}::standards/aws-foundational-security-best-practices/v/1.0.0",
+    "arn:aws:securityhub:${data.aws_region.current.region}::standards/cis-aws-foundations-benchmark/v/1.4.0",
+    "arn:aws:securityhub:${data.aws_region.current.region}::standards/pci-dss/v/3.2.1"
   ]
 
   security_hub_standards_arns = var.aws_security_hub.standards_arns != null ? var.aws_security_hub.standards_arns : local.security_hub_standards_arns_default
@@ -35,5 +35,5 @@ locals {
     "cis-aws-foundations-benchmark/v", join(",", local.security_hub_standards_arns)
   )) > 0 ? true : false
 
-  all_organisation_regions = toset(distinct(concat([var.regions.home_region], var.regions.linked_regions, var.regions.allowed_regions, [data.aws_region.current.name])))
+  all_organisation_regions = toset(distinct(concat([var.regions.home_region], var.regions.linked_regions, var.regions.allowed_regions, [data.aws_region.current.region])))
 }

--- a/tests/datadog.tftest.hcl
+++ b/tests/datadog.tftest.hcl
@@ -22,7 +22,7 @@ mock_provider "datadog" {}
 mock_provider "aws" {
   mock_data "aws_region" {
     defaults = {
-      name = "eu-central-1"
+      region = "eu-central-1"
     }
   }
 
@@ -90,7 +90,7 @@ mock_provider "aws" {
 
   mock_data "aws_region" {
     defaults = {
-      name = "eu-central-1"
+      region = "eu-central-1"
     }
   }
 
@@ -118,7 +118,7 @@ mock_provider "aws" {
 
   mock_data "aws_region" {
     defaults = {
-      name = "eu-central-1"
+      region = "eu-central-1"
     }
   }
 

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.54.0"
+      version               = ">= 6.7.0"
       configuration_aliases = [aws.audit, aws.logging]
     }
     datadog = {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

In AWS provider 6.x `data.aws_region`'s `name` attribute is deprecated and `region` attribute should be used instead.

## :rocket: Motivation

This solves deprecation warnings.

## :pencil: Additional Information

Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#name-1
