### PR TITLE
feat!: Refactor Inspector setup to multi-region module structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ module "landing_zone" {
 | <a name="module_datadog_logging"></a> [datadog\_logging](#module\_datadog\_logging) | schubergphilis/mcaf-datadog/aws | ~> 0.9.0 |
 | <a name="module_datadog_master"></a> [datadog\_master](#module\_datadog\_master) | schubergphilis/mcaf-datadog/aws | ~> 0.9.0 |
 | <a name="module_guardduty"></a> [guardduty](#module\_guardduty) | ./modules/guardduty | n/a |
+| <a name="module_inspector"></a> [inspector](#module\_inspector) | ./modules/inspector | n/a |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | schubergphilis/mcaf-kms/aws | ~> 0.3.0 |
 | <a name="module_kms_key_audit"></a> [kms\_key\_audit](#module\_kms\_key\_audit) | schubergphilis/mcaf-kms/aws | ~> 0.3.0 |
 | <a name="module_kms_key_logging"></a> [kms\_key\_logging](#module\_kms\_key\_logging) | schubergphilis/mcaf-kms/aws | ~> 0.3.0 |
@@ -535,11 +536,6 @@ module "landing_zone" {
 | [aws_iam_role.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.sns_feedback_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_service_linked_role.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
-| [aws_inspector2_delegated_admin_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_delegated_admin_account) | resource |
-| [aws_inspector2_enabler.audit_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler) | resource |
-| [aws_inspector2_enabler.member_accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler) | resource |
-| [aws_inspector2_member_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_member_association) | resource |
-| [aws_inspector2_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_organization_configuration) | resource |
 | [aws_organizations_policy.aiservices_opt_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.allowed_regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.deny_root_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |

--- a/config.tf
+++ b/config.tf
@@ -186,8 +186,7 @@ module "aws_config_recorder" {
 
   source = "./modules/aws-config-recorder"
 
-  region = each.value
-
+  region                      = each.value
   delivery_frequency          = var.aws_config.delivery_frequency
   iam_service_linked_role_arn = aws_iam_service_linked_role.config.arn
   kms_key_arn                 = module.kms_key_logging.arn

--- a/guardduty.tf
+++ b/guardduty.tf
@@ -8,8 +8,7 @@ module "guardduty" {
 
   source = "./modules/guardduty"
 
-  region = each.value
-
+  region                        = each.value
   ebs_malware_protection_status = var.aws_guardduty.ebs_malware_protection_status
   eks_audit_logs_status         = var.aws_guardduty.eks_audit_logs_status
   finding_publishing_frequency  = var.aws_guardduty.finding_publishing_frequency

--- a/inspector.tf
+++ b/inspector.tf
@@ -4,69 +4,25 @@ locals {
     if account.id != var.control_tower_account_ids.audit
     && !contains(var.aws_inspector.excluded_member_account_ids, account.id)
   ] : []
-
-  inspector_enabled_resource_types = var.aws_inspector.enabled ? compact([
-    var.aws_inspector.enable_scan_ec2 ? "EC2" : "",
-    var.aws_inspector.enable_scan_ecr ? "ECR" : "",
-    var.aws_inspector.enable_scan_lambda ? "LAMBDA" : "",
-    var.aws_inspector.enable_scan_lambda_code ? "LAMBDA_CODE" : "",
-  ]) : []
 }
 
-// Delegate the admin account to the audit account
-resource "aws_inspector2_delegated_admin_account" "default" {
-  count = var.aws_inspector.enabled == true ? 1 : 0
+module "inspector" {
+  for_each = var.aws_inspector.enabled == true ? local.all_organisation_regions : []
 
-  account_id = var.control_tower_account_ids.audit
-}
-
-// Activate Inspector in the audit account
-resource "aws_inspector2_enabler" "audit_account" {
-  count    = var.aws_inspector.enabled == true ? 1 : 0
-  provider = aws.audit
-
-  account_ids    = [var.control_tower_account_ids.audit]
-  resource_types = local.inspector_enabled_resource_types
-
-  depends_on = [aws_inspector2_delegated_admin_account.default]
-}
-
-// Associate the member accounts with the audit account
-resource "aws_inspector2_member_association" "default" {
-  for_each = toset(local.inspector_members_account_ids)
-  provider = aws.audit
-
-  account_id = each.value
-
-  depends_on = [aws_inspector2_enabler.audit_account]
-}
-
-// Activate Inspector in the member accounts
-resource "aws_inspector2_enabler" "member_accounts" {
-  count    = var.aws_inspector.enabled == true ? 1 : 0
-  provider = aws.audit
-
-  account_ids    = toset(local.inspector_members_account_ids)
-  resource_types = local.inspector_enabled_resource_types
-
-  timeouts {
-    create = var.aws_inspector.resource_create_timeout
+  providers = {
+    aws.management      = aws
+    aws.delegated_admin = aws.audit
   }
 
-  depends_on = [aws_inspector2_member_association.default]
-}
+  source = "./modules/inspector"
 
-// Auto-enable Inspector in the new member accounts
-resource "aws_inspector2_organization_configuration" "default" {
-  count    = var.aws_inspector.enabled == true ? 1 : 0
-  provider = aws.audit
+  region = each.value
 
-  auto_enable {
-    ec2         = var.aws_inspector.enable_scan_ec2
-    ecr         = var.aws_inspector.enable_scan_ecr
-    lambda      = var.aws_inspector.enable_scan_lambda
-    lambda_code = var.aws_inspector.enable_scan_lambda_code
-  }
-
-  depends_on = [aws_inspector2_enabler.member_accounts]
+  enable_scan_ec2         = var.aws_inspector.enable_scan_ec2
+  enable_scan_ecr         = var.aws_inspector.enable_scan_ecr
+  enable_scan_lambda      = var.aws_inspector.enable_scan_lambda
+  enable_scan_lambda_code = var.aws_inspector.enable_scan_lambda_code
+  member_account_ids      = local.inspector_members_account_ids
+  resource_create_timeout = var.aws_inspector.resource_create_timeout
+  tags                    = var.tags
 }

--- a/inspector.tf
+++ b/inspector.tf
@@ -16,13 +16,15 @@ module "inspector" {
 
   source = "./modules/inspector"
 
-  region = each.value
-
-  enable_scan_ec2         = var.aws_inspector.enable_scan_ec2
-  enable_scan_ecr         = var.aws_inspector.enable_scan_ecr
-  enable_scan_lambda      = var.aws_inspector.enable_scan_lambda
-  enable_scan_lambda_code = var.aws_inspector.enable_scan_lambda_code
+  region                  = each.value
   member_account_ids      = local.inspector_members_account_ids
   resource_create_timeout = var.aws_inspector.resource_create_timeout
   tags                    = var.tags
+
+  enable_scan = {
+    ec2         = var.aws_inspector.enable_scan_ec2
+    ecr         = var.aws_inspector.enable_scan_ecr
+    lambda      = var.aws_inspector.enable_scan_lambda
+    lambda_code = var.aws_inspector.enable_scan_lambda_code
+  }
 }

--- a/modules/aws-config-recorder/main.tf
+++ b/modules/aws-config-recorder/main.tf
@@ -1,6 +1,5 @@
 resource "aws_config_configuration_recorder" "default" {
-  region = var.region
-
+  region   = var.region
   name     = "default"
   role_arn = var.iam_service_linked_role_arn
 
@@ -11,8 +10,7 @@ resource "aws_config_configuration_recorder" "default" {
 }
 
 resource "aws_config_delivery_channel" "default" {
-  region = var.region
-
+  region         = var.region
   name           = "default"
   s3_bucket_name = var.s3_bucket_name
   s3_key_prefix  = var.s3_key_prefix
@@ -27,9 +25,9 @@ resource "aws_config_delivery_channel" "default" {
 }
 
 resource "aws_config_configuration_recorder_status" "default" {
-  region = var.region
-
+  region     = var.region
   name       = aws_config_configuration_recorder.default.name
   is_enabled = true
+
   depends_on = [aws_config_delivery_channel.default]
 }

--- a/modules/guardduty/main.tf
+++ b/modules/guardduty/main.tf
@@ -7,8 +7,7 @@ data "aws_caller_identity" "delegated_admin" {
 resource "aws_guardduty_organization_admin_account" "default" {
   provider = aws.management
 
-  region = var.region
-
+  region           = var.region
   admin_account_id = data.aws_caller_identity.delegated_admin.account_id
 }
 
@@ -18,8 +17,7 @@ resource "aws_guardduty_detector" "delegated_admin" {
   #checkov:skip=CKV2_AWS_3: "Ensure GuardDuty is enabled to specific org/region" - False positive, GuardDuty is enabled by default.
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region                       = var.region
   enable                       = true
   finding_publishing_frequency = var.finding_publishing_frequency
   tags                         = var.tags
@@ -28,8 +26,7 @@ resource "aws_guardduty_detector" "delegated_admin" {
 resource "aws_guardduty_organization_configuration" "default" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region                           = var.region
   auto_enable_organization_members = "ALL"
   detector_id                      = aws_guardduty_detector.delegated_admin.id
 
@@ -39,8 +36,7 @@ resource "aws_guardduty_organization_configuration" "default" {
 resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protection" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "EBS_MALWARE_PROTECTION"
   auto_enable = var.ebs_malware_protection_status == true ? "ALL" : "NONE"
@@ -49,8 +45,7 @@ resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protect
 resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "EKS_AUDIT_LOGS"
   auto_enable = var.eks_audit_logs_status == true ? "ALL" : "NONE"
@@ -59,8 +54,7 @@ resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
 resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "LAMBDA_NETWORK_LOGS"
   auto_enable = var.lambda_network_logs_status == true ? "ALL" : "NONE"
@@ -69,8 +63,7 @@ resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs
 resource "aws_guardduty_organization_configuration_feature" "rds_login_events" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "RDS_LOGIN_EVENTS"
   auto_enable = var.rds_login_events_status == true ? "ALL" : "NONE"
@@ -79,8 +72,7 @@ resource "aws_guardduty_organization_configuration_feature" "rds_login_events" {
 resource "aws_guardduty_organization_configuration_feature" "s3_data_events" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "S3_DATA_EVENTS"
   auto_enable = var.s3_data_events_status == true ? "ALL" : "NONE"
@@ -89,8 +81,7 @@ resource "aws_guardduty_organization_configuration_feature" "s3_data_events" {
 resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region      = var.region
   detector_id = aws_guardduty_detector.delegated_admin.id
   name        = "RUNTIME_MONITORING"
   auto_enable = var.runtime_monitoring_status.enabled == true ? "ALL" : "NONE"

--- a/modules/inspector/README.md
+++ b/modules/inspector/README.md
@@ -1,0 +1,16 @@
+# Amazon Inspector
+
+This module enables Amazon Inspector across all accounts in an AWS Organization, following the AWS-recommended delegated administrator model.
+
+Inspector operates as a Regional service — meaning the delegated administrator must be configured per region.  
+
+The setup uses two providers:
+
+- `aws.management` → the management (payer) account, which designates the delegated Inspector administrator.  
+- `aws.delegated_admin` → the delegated administrator account, where Inspector is actually managed and organization-wide features are enabled.
+
+For detailed background on how Inspector integrates with AWS Organizations, see the AWS documentation:  
+🔗 [Inspector and AWS Organizations (AWS Docs)](https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html)
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/inspector/main.tf
+++ b/modules/inspector/main.tf
@@ -1,9 +1,9 @@
 locals {
   inspector_enabled_resource_types = compact([
-    var.enable_scan_ec2 ? "EC2" : "",
-    var.enable_scan_ecr ? "ECR" : "",
-    var.enable_scan_lambda ? "LAMBDA" : "",
-    var.enable_scan_lambda_code ? "LAMBDA_CODE" : "",
+    var.enable_scan.ec2 ? "EC2" : "",
+    var.enable_scan.ecr ? "ECR" : "",
+    var.enable_scan.lambda ? "LAMBDA" : "",
+    var.enable_scan.lambda_code ? "LAMBDA_CODE" : "",
   ])
 }
 
@@ -11,44 +11,39 @@ data "aws_caller_identity" "delegated_admin" {
   provider = aws.delegated_admin
 }
 
-// Amazon Inspector - Management account configuration
+# Management account configuration
 resource "aws_inspector2_delegated_admin_account" "default" {
-
-  region = var.region
-
+  region     = var.region
   account_id = data.aws_caller_identity.delegated_admin.account_id
 }
 
-// Amazon Inspector - Delegated administrator account configuration
+# Delegated administrator account configuration
 resource "aws_inspector2_enabler" "delegated_admin" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region         = var.region
   account_ids    = [data.aws_caller_identity.delegated_admin.account_id]
   resource_types = local.inspector_enabled_resource_types
 
   depends_on = [aws_inspector2_delegated_admin_account.default]
 }
 
-// Associate the member accounts with the delegated admin account
+# Associate the member accounts with the delegated admin account
 resource "aws_inspector2_member_association" "default" {
   for_each = toset(var.member_account_ids)
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region     = var.region
   account_id = each.value
 
   depends_on = [aws_inspector2_enabler.delegated_admin]
 }
 
-// Activate Inspector in the member accounts
+# Activate Inspector in the member accounts
 resource "aws_inspector2_enabler" "member_accounts" {
   provider = aws.delegated_admin
 
-  region = var.region
-
+  region         = var.region
   account_ids    = toset(var.member_account_ids)
   resource_types = local.inspector_enabled_resource_types
 
@@ -59,17 +54,17 @@ resource "aws_inspector2_enabler" "member_accounts" {
   depends_on = [aws_inspector2_member_association.default]
 }
 
-// Auto-enable Inspector in the new member accounts
+# Auto-enable Inspector in the new member accounts
 resource "aws_inspector2_organization_configuration" "default" {
   provider = aws.delegated_admin
 
   region = var.region
 
   auto_enable {
-    ec2         = var.enable_scan_ec2
-    ecr         = var.enable_scan_ecr
-    lambda      = var.enable_scan_lambda
-    lambda_code = var.enable_scan_lambda_code
+    ec2         = var.enable_scan.ec2
+    ecr         = var.enable_scan.ecr
+    lambda      = var.enable_scan.lambda
+    lambda_code = var.enable_scan.lambda_code
   }
 
   depends_on = [aws_inspector2_enabler.member_accounts]

--- a/modules/inspector/main.tf
+++ b/modules/inspector/main.tf
@@ -1,0 +1,76 @@
+locals {
+  inspector_enabled_resource_types = compact([
+    var.enable_scan_ec2 ? "EC2" : "",
+    var.enable_scan_ecr ? "ECR" : "",
+    var.enable_scan_lambda ? "LAMBDA" : "",
+    var.enable_scan_lambda_code ? "LAMBDA_CODE" : "",
+  ])
+}
+
+data "aws_caller_identity" "delegated_admin" {
+  provider = aws.delegated_admin
+}
+
+// Amazon Inspector - Management account configuration
+resource "aws_inspector2_delegated_admin_account" "default" {
+
+  region = var.region
+
+  account_id = data.aws_caller_identity.delegated_admin.account_id
+}
+
+// Amazon Inspector - Delegated administrator account configuration
+resource "aws_inspector2_enabler" "delegated_admin" {
+  provider = aws.delegated_admin
+
+  region = var.region
+
+  account_ids    = [data.aws_caller_identity.delegated_admin.account_id]
+  resource_types = local.inspector_enabled_resource_types
+
+  depends_on = [aws_inspector2_delegated_admin_account.default]
+}
+
+// Associate the member accounts with the delegated admin account
+resource "aws_inspector2_member_association" "default" {
+  for_each = toset(var.member_account_ids)
+  provider = aws.delegated_admin
+
+  region = var.region
+
+  account_id = each.value
+
+  depends_on = [aws_inspector2_enabler.delegated_admin]
+}
+
+// Activate Inspector in the member accounts
+resource "aws_inspector2_enabler" "member_accounts" {
+  provider = aws.delegated_admin
+
+  region = var.region
+
+  account_ids    = toset(var.member_account_ids)
+  resource_types = local.inspector_enabled_resource_types
+
+  timeouts {
+    create = var.resource_create_timeout
+  }
+
+  depends_on = [aws_inspector2_member_association.default]
+}
+
+// Auto-enable Inspector in the new member accounts
+resource "aws_inspector2_organization_configuration" "default" {
+  provider = aws.delegated_admin
+
+  region = var.region
+
+  auto_enable {
+    ec2         = var.enable_scan_ec2
+    ecr         = var.enable_scan_ecr
+    lambda      = var.enable_scan_lambda
+    lambda_code = var.enable_scan_lambda_code
+  }
+
+  depends_on = [aws_inspector2_enabler.member_accounts]
+}

--- a/modules/inspector/terraform.tf
+++ b/modules/inspector/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+      configuration_aliases = [
+        aws.management,
+        aws.delegated_admin
+      ]
+    }
+  }
+
+  required_version = ">= 1.9.0"
+}

--- a/modules/inspector/variables.tf
+++ b/modules/inspector/variables.tf
@@ -1,0 +1,52 @@
+variable "enable_scan_ec2" {
+  type        = bool
+  default     = true
+  description = "Whether AWS Inspector scans EC2 instances."
+}
+
+variable "enable_scan_ecr" {
+  type        = bool
+  default     = true
+  description = "Whether AWS Inspector scans ECR repositories."
+}
+
+variable "enable_scan_lambda" {
+  type        = bool
+  default     = true
+  description = "Whether AWS Inspector scans Lambda functions."
+}
+
+variable "enable_scan_lambda_code" {
+  type        = bool
+  default     = true
+  description = "Whether AWS Inspector scans Lambda function code."
+
+  validation {
+    condition     = !(var.enable_scan_lambda_code && !var.enable_scan_lambda)
+    error_message = "If 'enable_scan_lambda_code' is true, 'enable_scan_lambda' must also be true."
+  }
+}
+
+variable "member_account_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of AWS account IDs to include in Inspector scans."
+}
+
+variable "resource_create_timeout" {
+  type        = string
+  default     = "15m"
+  description = "Timeout for creating AWS Inspector resources."
+}
+
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the resources will be created. If omitted, the default provider region is used."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Map of tags"
+}

--- a/modules/inspector/variables.tf
+++ b/modules/inspector/variables.tf
@@ -1,29 +1,16 @@
-variable "enable_scan_ec2" {
-  type        = bool
-  default     = true
-  description = "Whether AWS Inspector scans EC2 instances."
-}
-
-variable "enable_scan_ecr" {
-  type        = bool
-  default     = true
-  description = "Whether AWS Inspector scans ECR repositories."
-}
-
-variable "enable_scan_lambda" {
-  type        = bool
-  default     = true
-  description = "Whether AWS Inspector scans Lambda functions."
-}
-
-variable "enable_scan_lambda_code" {
-  type        = bool
-  default     = true
-  description = "Whether AWS Inspector scans Lambda function code."
+variable "enable_scan" {
+  type = object({
+    ec2         = optional(bool, true)
+    ecr         = optional(bool, true)
+    lambda      = optional(bool, true)
+    lambda_code = optional(bool, true)
+  })
+  default     = {}
+  description = "Type of resources to scan."
 
   validation {
-    condition     = !(var.enable_scan_lambda_code && !var.enable_scan_lambda)
-    error_message = "If 'enable_scan_lambda_code' is true, 'enable_scan_lambda' must also be true."
+    condition     = !(var.enable_scan.lambda_code && !var.enable_scan.lambda)
+    error_message = "If enable_scan.lambda_code is true, enable_scan.lambda must also be true."
   }
 }
 

--- a/modules/security-baseline-regional/main.tf
+++ b/modules/security-baseline-regional/main.tf
@@ -1,18 +1,15 @@
 resource "aws_ebs_encryption_by_default" "default" {
-  region = var.region
-
+  region  = var.region
   enabled = var.aws_ebs_encryption_by_default
 }
 
 resource "aws_ebs_snapshot_block_public_access" "default" {
   region = var.region
-
-  state = var.aws_ebs_snapshot_block_public_access_state
+  state  = var.aws_ebs_snapshot_block_public_access_state
 }
 
 resource "aws_ssm_service_setting" "documents_public_sharing_permission" {
-  region = var.region
-
+  region        = var.region
   setting_id    = "/ssm/documents/console/public-sharing-permission"
   setting_value = var.aws_ssm_documents_public_sharing_permission
 }

--- a/organizations_policy_allowed_regions.tf
+++ b/organizations_policy_allowed_regions.tf
@@ -175,7 +175,8 @@ locals {
     local.us_east_1_edge_service_actions,
     local.us_east_1_global_service_actions,
     local.us_east_1_security_lake_aggregation_service_actions,
-    var.aws_guardduty.enabled ? ["guardduty:*"] : []
+    var.aws_guardduty.enabled ? ["guardduty:*"] : [],
+    var.aws_inspector.enabled ? ["inspector2:*"] : []
   ))
 
   # Statement #2:

--- a/scripts/v8-generate-moved-blocks-guardduty.sh
+++ b/scripts/v8-generate-moved-blocks-guardduty.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# --- Configuration ---
+OUTPUT_FILE="v8-moved-guardduty.tf"
+MODULE_NAME="landing_zone"
+# ----------------------
+
+echo "🔍 Scanning Terraform state for ${MODULE_NAME} aws_guardduty* resources..."
+read -rp '🏠 Enter home region (e.g., eu-central-1): ' HOME_REGION
+if [[ -z "${HOME_REGION:-}" ]]; then
+  echo "❌ Home region cannot be empty." >&2
+  exit 1
+fi
+
+echo "📝 Writing moved blocks to '${OUTPUT_FILE}'"
+: >"${OUTPUT_FILE}"
+
+terraform state list | grep -E "^module\.${MODULE_NAME}\.aws_guardduty" | while read -r resource; do
+  # Insert .module.guardduty["<home-region>"]. right after module.<MODULE_NAME>.
+  to_address=$(echo "$resource" | sed -E "s/^module\.${MODULE_NAME}\./module.${MODULE_NAME}.module.guardduty[\"${HOME_REGION}\"]./")
+
+  comment=""
+
+  # Special-case rename #1: detector.audit -> delegated_admin
+  if [[ "$resource" =~ ^module\.${MODULE_NAME}\.aws_guardduty_detector\.audit(\[0\])?$ ]]; then
+    to_address=$(echo "$to_address" | sed -E 's/(\.aws_guardduty_detector)\.audit/\1.delegated_admin/')
+    comment="# rename: audit -> delegated_admin"
+  fi
+
+  # Special-case rename #2: organization_admin_account.audit -> default
+  if [[ "$resource" =~ ^module\.${MODULE_NAME}\.aws_guardduty_organization_admin_account\.audit(\[0\])?$ ]]; then
+    to_address=$(echo "$to_address" | sed -E 's/(\.aws_guardduty_organization_admin_account)\.audit/\1.default/')
+    comment="# rename: audit -> default"
+  fi
+
+  # Remove trailing [0] from the TO address (keep it in FROM)
+  to_address=$(echo "$to_address" | sed -E 's/\[0\]$//')
+
+  {
+    [[ -n "$comment" ]] && echo "$comment"
+    echo "moved {"
+    echo "  from = ${resource}"
+    echo "  to   = ${to_address}"
+    echo "}"
+    echo
+  } >>"${OUTPUT_FILE}"
+done
+
+echo "✅ Done. Moved statements written to '${OUTPUT_FILE}'."
+echo "💡 Next: run 'terraform plan' to verify the changes."

--- a/scripts/v8-generate-moved-blocks-inspector.sh
+++ b/scripts/v8-generate-moved-blocks-inspector.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# --- Configuration ---
+OUTPUT_FILE="v8-moved-inspector.tf"
+MODULE_NAME="landing_zone"
+# ----------------------
+
+echo "🔍 Scanning Terraform state for ${MODULE_NAME} aws_inspector2* resources..."
+read -rp '🏠 Enter home region (e.g., eu-central-1): ' HOME_REGION
+if [[ -z "${HOME_REGION:-}" ]]; then
+  echo "❌ Home region cannot be empty." >&2
+  exit 1
+fi
+
+echo "📝 Writing moved blocks to '${OUTPUT_FILE}'"
+: >"${OUTPUT_FILE}"
+
+terraform state list | grep -E "^module\.${MODULE_NAME}\.aws_inspector2" | while read -r resource; do
+  # Insert .module.inspector["<home-region>"]. right after module.<MODULE_NAME>.
+  to_address=$(echo "$resource" | sed -E "s/^module\.${MODULE_NAME}\./module.${MODULE_NAME}.module.inspector[\"${HOME_REGION}\"]./")
+
+  # Special-case rename:
+  # module.<MODULE_NAME>.aws_inspector2_enabler.audit_account[0]
+  #   -> module.<MODULE_NAME>.module.inspector["<home>"].aws_inspector2_enabler.delegated_admin
+  if [[ "$resource" =~ ^module\.${MODULE_NAME}\.aws_inspector2_enabler\.audit_account(\[0\])?$ ]]; then
+    to_address=$(echo "$to_address" | sed -E 's/(\.aws_inspector2_enabler)\.audit_account/\1.delegated_admin/')
+  fi
+
+  # Remove trailing [0] from the TO address (keep it in FROM)
+  to_address=$(echo "$to_address" | sed -E 's/\[0\]$//')
+
+  {
+    # Optional comment for clarity on the renamed resource
+    if [[ "$resource" =~ ^module\.${MODULE_NAME}\.aws_inspector2_enabler\.audit_account(\[0\])?$ ]]; then
+      echo "# rename: audit_account -> delegated_admin"
+    fi
+    echo "moved {"
+    echo "  from = ${resource}"
+    echo "  to   = ${to_address}"
+    echo "}"
+    echo
+  } >>"${OUTPUT_FILE}"
+done
+
+echo "✅ Done. Moved statements written to '${OUTPUT_FILE}'."
+echo "💡 Next: run 'terraform plan' to verify the changes."


### PR DESCRIPTION
## :hammer_and_wrench: Summary
Refactored the Inspector setup to use a dedicated `inspector` module with multi-region support.

## :rocket: Motivation
Improve support for organizational services in a multi-region environment, ensuring inspector is consistently enabled and managed across all enabled regions.

## :pencil: Additional Information
- Added upgrade guide including helper scripts are to automatically generate the necessary `moved` statements.
- Existing `var.aws_inspector` schema remains backward-compatible.
