### PR TITLE
fix: Refactor iam_activity_master log metric filter to support Landing Zone 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ module "landing_zone" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.7.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.39 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.39, < 4.0 |
 | <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ module "landing_zone" {
 | [aws_caller_identity.audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_cloudwatch_log_group.cloudtrail_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_cloudwatch_log_groups.cloudtrail_master](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_groups) | data source |
 | [aws_iam_policy_document.aws_config_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/account_management.tf
+++ b/account_management.tf
@@ -5,10 +5,10 @@ locals {
   )
 
   iam_metric_filters_list = flatten([
-    for lg in data.aws_cloudwatch_log_groups.cloudtrail_master.log_groups : [
+    for log_group in data.aws_cloudwatch_log_groups.cloudtrail_master.log_group_names : [
       for pattern_key, pattern_value in local.iam_activity_patterns : {
-        key            = "${lg.log_group_name}-${pattern_key}"
-        log_group_name = lg.log_group_name
+        key            = "${log_group}-${pattern_key}"
+        log_group_name = log_group
         pattern_key    = pattern_key
         pattern_value  = pattern_value
       }

--- a/account_management.tf
+++ b/account_management.tf
@@ -1,12 +1,39 @@
-resource "aws_cloudwatch_log_metric_filter" "iam_activity_master" {
-  for_each = var.monitor_iam_activity ? merge(local.iam_activity, local.cloudtrail_activity_cis_aws_foundations) : {}
+locals {
+  iam_activity_patterns = merge(
+    local.iam_activity,
+    local.cloudtrail_activity_cis_aws_foundations
+  )
 
-  name           = "LandingZone-IAMActivity-${each.key}"
-  pattern        = each.value
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail_master[0].name
+  iam_metric_filters_list = flatten([
+    for lg in data.aws_cloudwatch_log_groups.cloudtrail_master.log_groups : [
+      for pattern_key, pattern_value in local.iam_activity_patterns : {
+        key            = "${lg.log_group_name}-${pattern_key}"
+        log_group_name = lg.log_group_name
+        pattern_key    = pattern_key
+        pattern_value  = pattern_value
+      }
+    ]
+  ])
+
+  iam_metric_filters = var.monitor_iam_activity ? {
+    for item in local.iam_metric_filters_list :
+    item.key => {
+      log_group_name = item.log_group_name
+      pattern_key    = item.pattern_key
+      pattern_value  = item.pattern_value
+    }
+  } : {}
+}
+
+resource "aws_cloudwatch_log_metric_filter" "iam_activity_master" {
+  for_each = local.iam_metric_filters
+
+  name           = "LandingZone-IAMActivity-${each.value.pattern_key}"
+  pattern        = each.value.pattern_value
+  log_group_name = each.value.log_group_name
 
   metric_transformation {
-    name      = "LandingZone-IAMActivity-${each.key}"
+    name      = "LandingZone-IAMActivity-${each.value.pattern_key}"
     namespace = "LandingZone-IAMActivity"
     value     = "1"
   }

--- a/data.tf
+++ b/data.tf
@@ -8,10 +8,8 @@ data "aws_caller_identity" "logging" {
 
 data "aws_caller_identity" "management" {}
 
-data "aws_cloudwatch_log_group" "cloudtrail_master" {
-  count = var.monitor_iam_activity ? 1 : 0
-
-  name = "aws-controltower/CloudTrailLogs"
+data "aws_cloudwatch_log_groups" "cloudtrail_master" {
+  log_group_name_prefix = "aws-controltower/CloudTrailLogs"
 }
 
 data "aws_organizations_organization" "default" {}

--- a/migration.tf
+++ b/migration.tf
@@ -1,0 +1,75 @@
+# Landing Zone 4.0 support for changes CloudTrail log group names
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["AwsConfigConfigChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-AwsConfigConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["AwsConfigConfigChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-AwsConfigConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["CloudTrailConfigChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-CloudTrailConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["IamPolicyChanges"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-IamPolicyChanges"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["KmsKeyDisableOrDeletion"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-KmsKeyDisableOrDeletion"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["ManagementConsoleAuthFailure"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-ManagementConsoleAuthFailure"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["NaclChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-NaclChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["NetworkGatewayChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-NetworkGatewayChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["RootActivity"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-RootActivity"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["RouteTableChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-RouteTableChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["S3BucketPolicyChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-S3BucketPolicyChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["SecurityGroupChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-SecurityGroupChange"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["SSO"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-SSO"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["UnauthorizedApiCalls"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-UnauthorizedApiCalls"]
+}
+
+moved {
+  from = aws_cloudwatch_log_metric_filter.iam_activity_master["VpcChange"]
+  to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-VpcChange"]
+}

--- a/migration.tf
+++ b/migration.tf
@@ -73,3 +73,82 @@ moved {
   from = aws_cloudwatch_log_metric_filter.iam_activity_master["VpcChange"]
   to   = aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-VpcChange"]
 }
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["AwsConfigConfigChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-AwsConfigConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["AwsConfigConfigChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-AwsConfigConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["CloudTrailConfigChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-CloudTrailConfigChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["IamPolicyChanges"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-IamPolicyChanges"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["KmsKeyDisableOrDeletion"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-KmsKeyDisableOrDeletion"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["ManagementConsoleAuthFailure"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-ManagementConsoleAuthFailure"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["NaclChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-NaclChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["NetworkGatewayChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-NetworkGatewayChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["RootActivity"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-RootActivity"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["RouteTableChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-RouteTableChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["S3BucketPolicyChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-S3BucketPolicyChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["SecurityGroupChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-SecurityGroupChange"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["SSO"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-SSO"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["UnauthorizedApiCalls"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-UnauthorizedApiCalls"]
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.iam_activity_master["VpcChange"]
+  to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-VpcChange"]
+}
+
+
+
+

--- a/moved.tf
+++ b/moved.tf
@@ -148,7 +148,3 @@ moved {
   from = aws_cloudwatch_metric_alarm.iam_activity_master["VpcChange"]
   to   = aws_cloudwatch_metric_alarm.iam_activity_master["aws-controltower/CloudTrailLogs-VpcChange"]
 }
-
-
-
-

--- a/terraform.tf
+++ b/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.39"
+      version = ">= 3.39, < 4.0"
     }
     mcaf = {
       source  = "schubergphilis/mcaf"


### PR DESCRIPTION
Landing zone 4.0 now uses postfixes in the CloudTrail name:

<img width="1600" height="588" alt="image" src="https://github.com/user-attachments/assets/0601ddc7-d61f-455d-bffb-9084dc2af954" />
https://docs.aws.amazon.com/controltower/latest/userguide/doc-history.html

## :hammer_and_wrench: Summary

With the new Landing Zone 4.0m the CloudTrail log group is not `aws-controltower/CloudTrailLogs` but has a suffix (done so people can enable/disable/enable/disable and get new log groups). To support this the change is to fetch ALL groups that start with `aws-controltower/CloudTrailLogs`. Although this is in theory always 1 group, the Metric Log filters are just added to all the groups dynamically.

All the groups are mapped with all the filter patters and then added. Since the resource key had to change to support multiple groups (the loggroup name is added) this causes a recreate. This is fixed with moved statements

Example old resource name:
`module.landing_zone.aws_cloudwatch_log_metric_filter.iam_activity_master["KmsKeyDisableOrDeletion"]`
And the new resource name:
`module.landing_zone.aws_cloudwatch_log_metric_filter.iam_activity_master["aws-controltower/CloudTrailLogs-KmsKeyDisableOrDeletion"]`


## :rocket: Motivation

New Landingzones that deploy with 4.0 don't have `aws-controltower/CloudTrailLogs` anymore but have a suffix (e.g. `aws-controltower/CloudTrailLogs-s0j-ybe`). So the old code breaks and has to be fixed. No functional changes so a patch version.

## :pencil: Additional Information

Only "change" is that the landingzone now supports multiple CloudTrail log groups. In normal cases there will be only one.

Also added an explicit Version Lock on the DataDog provider. V4 throws errors so  until the DataDog Account module is updates lock it. (It broke for me in my LandingZone deployment) It also broke the CI checks