### PR TITLE
fix: Add Delegated administrator policy for Security Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ module "landing_zone" {
 | [aws_organizations_policy_attachment.allowed_regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 | [aws_organizations_policy_attachment.deny_root_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 | [aws_organizations_policy_attachment.lz_root_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
+| [aws_organizations_resource_policy.security_hub_delegated_administrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_resource_policy) | resource |
 | [aws_securityhub_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
 | [aws_securityhub_account.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
 | [aws_securityhub_configuration_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_configuration_policy) | resource |
@@ -548,6 +549,7 @@ module "landing_zone" {
 | [aws_iam_policy_document.kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.security_hub_delegated_administrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [aws_organizations_organizational_units.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organizational_units) | data source |

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -24,6 +24,116 @@ resource "aws_securityhub_member" "management" {
 }
 
 // AWS Security Hub - Audit account configuration and enrollment
+data "aws_iam_policy_document" "security_hub_delegated_administrator" {
+  statement {
+    sid = "SecurityServicesDelegatingOrgReadActions"
+    actions = [
+      "organizations:ListRoots"
+    ]
+    resources = ["*"]
+    principals {
+      identifiers = ["arn:aws:iam::${var.control_tower_account_ids.audit}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "SecurityServicesDelegatingNecessaryOrgManagementActions"
+    actions = [
+      "organizations:DescribeOrganization",
+      "organizations:DescribeOrganizationalUnit",
+      "organizations:DescribeAccount",
+      "organizations:ListRoots",
+      "organizations:ListOrganizationalUnitsForParent",
+      "organizations:ListParents",
+      "organizations:ListChildren",
+      "organizations:ListAccounts",
+      "organizations:ListAccountsForParent",
+      "organizations:ListTagsForResource",
+      "organizations:ListDelegatedAdministrators",
+      "organizations:ListHandshakesForAccount"
+    ]
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:root/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:organization/${data.aws_organizations_organization.default.id}",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:ou/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:account/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/securityhub_policy/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/inspector_policy/*",
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::${var.control_tower_account_ids.audit}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "SecurityServicesDelegatingPolicyDescribeActions"
+    actions = [
+      "organizations:DescribePolicy",
+      "organizations:DescribeEffectivePolicy",
+      "organizations:ListPolicies",
+      "organizations:ListPoliciesForTarget",
+      "organizations:ListTargetsForPolicy"
+    ]
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:root/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:ou/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:account/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/securityhub_policy/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/inspector_policy/*",
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::${var.control_tower_account_ids.audit}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "SecurityServicesDelegatingPolicyMutationActions"
+    actions = [
+      "organizations:CreatePolicy",
+      "organizations:UpdatePolicy",
+      "organizations:DeletePolicy",
+      "organizations:AttachPolicy",
+      "organizations:DetachPolicy",
+      "organizations:EnablePolicyType",
+      "organizations:DisablePolicyType"
+    ]
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:root/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:ou/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:account/${data.aws_organizations_organization.default.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/securityhub_policy/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/inspector_policy/*",
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::${var.control_tower_account_ids.audit}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid = "SecurityServicesDelegatingPolicyTagActions"
+    actions = [
+      "organizations:TagResource",
+      "organizations:UntagResource"
+    ]
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/securityhub_policy/*",
+      "arn:aws:organizations::${data.aws_caller_identity.management.account_id}:policy/${data.aws_organizations_organization.default.id}/inspector_policy/*",
+    ]
+    principals {
+      identifiers = ["arn:aws:iam::${var.control_tower_account_ids.audit}:root"]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_organizations_resource_policy" "security_hub_delegated_administrator" {
+  content = data.aws_iam_policy_document.security_hub_delegated_administrator.json
+}
+
 resource "aws_securityhub_account" "default" {
   provider = aws.audit
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Add the policy that's missing when trying to assign a delegated admin for securityhub with new AWS accounts:

<img width="986" height="574" alt="image" src="https://github.com/user-attachments/assets/229a6023-809a-4819-b0bc-f47fee0e8c0d" />

Worked out the "copy/paste this policy" into Terraform code...

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
