### PR TITLE
fix: Remove account level security hub configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,8 +530,6 @@ module "landing_zone" {
 | [aws_securityhub_configuration_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_configuration_policy) | resource |
 | [aws_securityhub_configuration_policy_association.root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_configuration_policy_association) | resource |
 | [aws_securityhub_finding_aggregator.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_finding_aggregator) | resource |
-| [aws_securityhub_member.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_member) | resource |
-| [aws_securityhub_member.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_member) | resource |
 | [aws_securityhub_organization_admin_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_admin_account) | resource |
 | [aws_securityhub_organization_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_configuration) | resource |
 | [aws_sns_topic.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |

--- a/removed.tf
+++ b/removed.tf
@@ -27,3 +27,20 @@ removed {
     destroy = false
   }
 }
+
+# Security Hub membership is handled by the "mcaf-lz" Security Hub Configuration Policy.
+removed {
+  from = aws_securityhub_member.management
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_securityhub_member.logging
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -11,18 +11,6 @@ resource "aws_securityhub_account" "management" {
   depends_on = [aws_securityhub_organization_configuration.default]
 }
 
-resource "aws_securityhub_member" "management" {
-  provider = aws.audit
-
-  account_id = data.aws_caller_identity.management.account_id
-
-  depends_on = [aws_securityhub_account.management]
-
-  lifecycle {
-    ignore_changes = [invite]
-  }
-}
-
 // AWS Security Hub - Audit account configuration and enrollment
 resource "aws_securityhub_account" "default" {
   provider = aws.audit
@@ -124,17 +112,4 @@ resource "aws_sns_topic_subscription" "security_hub_findings" {
   endpoint_auto_confirms = length(regexall("http", each.value.protocol)) > 0
   protocol               = each.value.protocol
   topic_arn              = aws_sns_topic.security_hub_findings.arn
-}
-
-// AWS Security Hub - Logging account enrollment
-resource "aws_securityhub_member" "logging" {
-  provider = aws.audit
-
-  account_id = data.aws_caller_identity.logging.account_id
-
-  lifecycle {
-    ignore_changes = [invite]
-  }
-
-  depends_on = [aws_securityhub_organization_configuration.default]
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

With Security Hub central configuration and the Security Hub Configuration Policy in place, managing individual is not needed anymore. If the Policy is created/enabled before the account is configured it even breaks TF.

Account configuration implementation: https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/176
Central configuration implementation: https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/216

## :rocket: Motivation

Depending on the order this potentially breaks new TF deployments

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
