### PR TITLE
fix: Increase timeout of the aws_securityhub_configuration_policy_association

### DIFF
--- a/security_hub.tf
+++ b/security_hub.tf
@@ -76,6 +76,10 @@ resource "aws_securityhub_configuration_policy_association" "root" {
 
   target_id = data.aws_organizations_organization.default.roots[0].id
   policy_id = aws_securityhub_configuration_policy.default.id
+
+  timeouts {
+    create = "5m"
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "security_hub_findings" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

For some reason it takes longer than 90 seconds to apply the `aws_securityhub_configuration_policy_association`. As a result Terraform keeps reapplying on each run (although it's successfully applied, just not within the 90 seconds default timeout.

So increase the timeout on the create so it has time to properly finish.

Error:

```Error: waiting for Security Hub Configuration Policy Association (XXX) success: timeout while waiting for state to become 'SUCCESS' (last state: 'PENDING', timeout: 1m30s):```
