### PR TITLE
fix: Add the Permission set ARN output

### DIFF
--- a/modules/permission-set/README.md
+++ b/modules/permission-set/README.md
@@ -195,5 +195,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the permission set. |
 <!-- END_TF_DOCS -->

--- a/modules/permission-set/outputs.tf
+++ b/modules/permission-set/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "The ARN of the permission set."
+  value       = local.permission_set_arn
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Noticed that the Arn is not outputted. Might be nice to make it available

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
