### PR TITLE
fix: Add permission set name output

### DIFF
--- a/modules/permission-set/README.md
+++ b/modules/permission-set/README.md
@@ -198,4 +198,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the permission set. |
+| <a name="output_name"></a> [name](#output\_name) | The Name of the permission set. |
 <!-- END_TF_DOCS -->

--- a/modules/permission-set/README.md
+++ b/modules/permission-set/README.md
@@ -198,5 +198,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the permission set. |
-| <a name="output_name"></a> [name](#output\_name) | The Name of the permission set. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the permission set. |
 <!-- END_TF_DOCS -->

--- a/modules/permission-set/main.tf
+++ b/modules/permission-set/main.tf
@@ -9,8 +9,9 @@ locals {
     ]
   ])
 
-  instance_arn       = var.create ? aws_ssoadmin_permission_set.default[0].instance_arn : data.aws_ssoadmin_permission_set.default[0].instance_arn
-  permission_set_arn = var.create ? aws_ssoadmin_permission_set.default[0].arn : data.aws_ssoadmin_permission_set.default[0].arn
+  instance_arn        = var.create ? aws_ssoadmin_permission_set.default[0].instance_arn : data.aws_ssoadmin_permission_set.default[0].instance_arn
+  permission_set_arn  = var.create ? aws_ssoadmin_permission_set.default[0].arn : data.aws_ssoadmin_permission_set.default[0].arn
+  permission_set_name = var.create ? aws_ssoadmin_permission_set.default[0].name : data.aws_ssoadmin_permission_set.default[0].name
 }
 
 data "aws_ssoadmin_instances" "default" {}

--- a/modules/permission-set/outputs.tf
+++ b/modules/permission-set/outputs.tf
@@ -4,7 +4,7 @@ output "arn" {
 }
 
 output "name" {
-  description = "The Name of the permission set."
+  description = "The name of the permission set."
   value       = local.permission_set_name
 }
 

--- a/modules/permission-set/outputs.tf
+++ b/modules/permission-set/outputs.tf
@@ -2,3 +2,9 @@ output "arn" {
   description = "The ARN of the permission set."
   value       = local.permission_set_arn
 }
+
+output "name" {
+  description = "The Name of the permission set."
+  value       = local.permission_set_name
+}
+


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Besides the ARN, it's also handy to have the name of the permission set available as an output.

## :rocket: Motivation

Sometimes you need information of the permission set in other places, so the information can be useful.

## :pencil: Additional Information

Made it available as a `local` to be consistent with the ARN